### PR TITLE
docs: Fix broken reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ license](https://opensource.org/licenses/MIT). See the [`LICENSE` file in this
 repository](https://github.com/ash-project/reactor/blob/main/LICENSE)
 for details.
 
-[saga pattern](https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/saga/saga)
+[saga pattern]: https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/saga/saga
 [dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph


### PR DESCRIPTION
The malformed markdown was preventing the links from being converted correctly.

<img width="805" alt="Screenshot 2023-06-15 at 2 56 16 pm" src="https://github.com/ash-project/reactor/assets/543859/a73b968c-0bdb-4d75-becf-e45b5a4ba161">

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
