### PR TITLE
improvement(Executor): track concurrent process usage across multiple Reactors.

### DIFF
--- a/lib/reactor/application.ex
+++ b/lib/reactor/application.ex
@@ -6,7 +6,10 @@ defmodule Reactor.Application do
   @impl true
   @spec start(any, any) :: {:error, any} | {:ok, pid}
   def start(_type, _args) do
-    [{PartitionSupervisor, child_spec: Task.Supervisor, name: Reactor.TaskSupervisor}]
+    [
+      {PartitionSupervisor, child_spec: Task.Supervisor, name: Reactor.TaskSupervisor},
+      Reactor.Executor.ConcurrencyTracker
+    ]
     |> Supervisor.start_link(strategy: :one_for_one, name: __MODULE__.Supervisor)
   end
 end

--- a/lib/reactor/dsl/compose.ex
+++ b/lib/reactor/dsl/compose.ex
@@ -2,7 +2,7 @@ defmodule Reactor.Dsl.Compose do
   @moduledoc """
   The `compose` DSL entity struct.
 
-  See `Reactor.Dsl`.
+  See the `Reactor` DSL docs.
   """
   defstruct arguments: [], name: nil, reactor: nil
 

--- a/lib/reactor/executor/concurrency_tracker.ex
+++ b/lib/reactor/executor/concurrency_tracker.ex
@@ -1,0 +1,112 @@
+defmodule Reactor.Executor.ConcurrencyTracker do
+  @moduledoc """
+  Manage shared concurrency pools for multiple Reactors.
+
+  When running a Reactor you can pass the `concurrency_key` option, which will
+  cause the Reactor to use the specified pool to ensure that the combined
+  Reactors never exceed the pool's available concurrency limit.
+
+  This avoids nested Reactors spawning too many workers and thrashing the
+  system.
+  """
+
+  use GenServer
+
+  @type pool_key :: reference()
+
+  @doc false
+  @spec start_link(any) :: GenServer.on_start()
+  def start_link(_), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  @doc false
+  @impl true
+  @spec init(any) :: {:ok, atom | :ets.tid()}
+  def init(_) do
+    table = :ets.new(__MODULE__, ~w[set named_table public]a)
+    {:ok, table}
+  end
+
+  @doc false
+  @impl true
+  def handle_cast({:monitor, pid}, table) do
+    Process.monitor(pid)
+    {:noreply, table}
+  end
+
+  @doc false
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, table) do
+    :ets.select_delete(table, [{{:_, :_, :_, :"$1"}, [], [{:==, :"$1", pid}]}])
+    {:noreply, table}
+  end
+
+  @doc """
+  Allocate a new concurrency pool and set the maximum limit.
+  """
+  @spec allocate_pool(non_neg_integer) :: pool_key
+  def allocate_pool(concurrency_limit) do
+    key = make_ref()
+    caller = self()
+    :ets.insert(__MODULE__, {key, concurrency_limit, concurrency_limit, caller})
+    GenServer.cast(__MODULE__, {:monitor, caller})
+    key
+  end
+
+  @doc """
+  Release the concurrency pool.
+
+  This deletes the pool, however doesn't affect any processes currently using
+  it.  No more resources can be acquired by users of the pool key.
+  """
+  @spec release_pool(pool_key) :: :ok
+  def release_pool(pool_key) do
+    :ets.delete(__MODULE__, pool_key)
+    :ok
+  end
+
+  @doc """
+  Release a concurrency allocation back to the pool.
+  """
+  @spec release(pool_key) :: :ok
+  def release(key) do
+    :ets.select_replace(__MODULE__, [
+      {{:"$1", :"$2", :"$3", :"$4"},
+       [{:andalso, {:"=<", {:+, :"$2", 1}, :"$3"}, {:==, :"$1", key}}],
+       [{{:"$1", {:+, :"$2", 1}, :"$3", :"$4"}}]}
+    ])
+
+    :ok
+  end
+
+  @doc """
+  Attempt to acquire a concurrency allocation from the pool.
+
+  Returns `:ok` if the allocation was successful, otherwise `:error`.
+  """
+  @spec acquire(pool_key) :: :ok | :error
+  def acquire(key) do
+    __MODULE__
+    |> :ets.select_replace([
+      {{:"$1", :"$2", :"$3", :"$4"}, [{:andalso, {:>=, {:-, :"$2", 1}, 0}, {:==, :"$1", key}}],
+       [{{:"$1", {:-, :"$2", 1}, :"$3", :"$4"}}]}
+    ])
+    |> case do
+      0 -> :error
+      1 -> :ok
+    end
+  end
+
+  @doc """
+  Report the available and maximum concurrency for a pool.
+  """
+  @spec status(pool_key) :: {:ok, available, limit} | {:error, any}
+        when available: non_neg_integer(), limit: pos_integer()
+  def status(key) do
+    __MODULE__
+    |> :ets.lookup(key)
+    |> case do
+      [{_, available, limit, _}] -> {:ok, available, limit}
+      [] -> {:error, "Unknown concurrency pool"}
+    end
+  end
+end

--- a/lib/reactor/executor/state.ex
+++ b/lib/reactor/executor/state.ex
@@ -5,36 +5,75 @@ defmodule Reactor.Executor.State do
   This is run-time only information.
   """
 
-  defstruct async?: true,
+  @defaults %{
+    async?: true,
+    halt_timeout: 5000,
+    max_iterations: :infinity,
+    timeout: :infinity
+  }
+
+  defstruct async?: @defaults.async?,
+            concurrency_key: nil,
             current_tasks: %{},
             errors: [],
-            halt_timeout: 5000,
+            halt_timeout: @defaults.halt_timeout,
             max_concurrency: nil,
-            max_iterations: :infinity,
+            max_iterations: @defaults.max_iterations,
+            pool_owner: false,
             retries: %{},
-            timeout: :infinity,
-            started_at: nil
+            started_at: nil,
+            timeout: @defaults.timeout
 
-  alias Reactor.Step
+  alias Reactor.{Executor.ConcurrencyTracker, Step}
 
   @type t :: %__MODULE__{
           async?: boolean,
+          concurrency_key: ConcurrencyTracker.pool_key(),
           current_tasks: %{Task.t() => Step.t()},
           errors: [any],
           halt_timeout: pos_integer() | :infinity,
           max_concurrency: pos_integer(),
           max_iterations: pos_integer() | :infinity,
+          pool_owner: boolean,
           retries: %{reference() => pos_integer()},
-          timeout: pos_integer() | :infinity,
-          started_at: DateTime.t()
+          started_at: DateTime.t(),
+          timeout: pos_integer() | :infinity
         }
 
   @doc false
   @spec init(map) :: t
   def init(attrs \\ %{}) do
+    @defaults
+    |> Map.merge(attrs)
+    |> do_init()
+  end
+
+  defp do_init(attrs) do
     attrs
-    |> Map.put_new_lazy(:max_concurrency, &System.schedulers_online/0)
+    |> maybe_set_max_concurrency()
+    |> maybe_allocate_concurrency_pool()
     |> Map.put(:started_at, DateTime.utc_now())
     |> then(&struct(__MODULE__, &1))
+  end
+
+  defp maybe_set_max_concurrency(attrs)
+       when is_integer(attrs.max_concurrency) and attrs.max_concurrency > 0,
+       do: attrs
+
+  defp maybe_set_max_concurrency(attrs) when attrs.async? == false,
+    do: Map.put(attrs, :max_concurrency, 0)
+
+  defp maybe_set_max_concurrency(attrs),
+    do: Map.put(attrs, :max_concurrency, System.schedulers_online())
+
+  defp maybe_allocate_concurrency_pool(attrs) when is_reference(attrs.concurrency_key) do
+    attrs
+    |> Map.put(:pool_owner, false)
+  end
+
+  defp maybe_allocate_concurrency_pool(attrs) do
+    attrs
+    |> Map.put(:concurrency_key, ConcurrencyTracker.allocate_pool(attrs.max_concurrency))
+    |> Map.put(:pool_owner, true)
   end
 end

--- a/lib/reactor/executor/sync.ex
+++ b/lib/reactor/executor/sync.ex
@@ -14,7 +14,7 @@ defmodule Reactor.Executor.Sync do
   def run(reactor, state, nil), do: {:continue, reactor, state}
 
   def run(reactor, state, step) do
-    case Executor.StepRunner.run(reactor, step) do
+    case Executor.StepRunner.run(reactor, step, state.concurrency_key) do
       :retry ->
         state = increment_retries(state, step)
 

--- a/lib/reactor/step/around.ex
+++ b/lib/reactor/step/around.ex
@@ -121,7 +121,11 @@ defmodule Reactor.Step.Around do
     with {:ok, reactor} <- build_inputs(Builder.new(), arguments),
          {:ok, reactor} <- build_steps(reactor, steps),
          {:ok, reactor} <- build_return_step(reactor, steps),
-         {:ok, result} <- Reactor.run(reactor, context, async?: allow_async?) do
+         {:ok, result} <-
+           Reactor.run(reactor, context,
+             async?: allow_async?,
+             concurrency_key: context.concurrency_key
+           ) do
       {:ok, result}
     else
       {:error, reason} -> {:error, reason}

--- a/lib/reactor/step/compose.ex
+++ b/lib/reactor/step/compose.ex
@@ -34,7 +34,7 @@ defmodule Reactor.Step.Compose do
   end
 
   defp handle_recursive_reactor(reactor, arguments, context),
-    do: Reactor.run(reactor, arguments, context, [])
+    do: Reactor.run(reactor, arguments, context, concurrency_key: context.concurrency_key)
 
   defp handle_non_recursive_reactor(reactor, arguments, context) when is_atom(reactor) do
     with {:ok, reactor} <- Info.to_struct(reactor) do

--- a/test/reactor/executor/concurrency_tracker_test.exs
+++ b/test/reactor/executor/concurrency_tracker_test.exs
@@ -1,0 +1,64 @@
+defmodule Reactor.Executor.ConcurrencyTrackerTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Reactor.Executor.ConcurrencyTracker
+
+  describe "allocate_pool/1" do
+    test "it returns a new pool key" do
+      assert pool = allocate_pool(16)
+      assert is_reference(pool)
+    end
+
+    test "it monitors the requesting process and destroys the pool when it exits" do
+      pool =
+        fn ->
+          pool = allocate_pool(16)
+          assert {:ok, _, _} = status(pool)
+          pool
+        end
+        |> Task.async()
+        |> Task.await()
+
+      # We have to wait for the concurrency tracker to process the request.
+      Process.sleep(10)
+
+      assert {:error, _} = status(pool)
+    end
+  end
+
+  describe "acquire/1" do
+    test "when there is available concurrency in the pool, it returns ok" do
+      pool = allocate_pool(16)
+      assert :ok = acquire(pool)
+      assert {:ok, 15, 16} = status(pool)
+    end
+
+    test "when there is no available concurrency in the pool, it returns error" do
+      pool = allocate_pool(0)
+      assert :error = acquire(pool)
+    end
+
+    test "when there is 1 slot left, it can be acquired" do
+      pool = allocate_pool(1)
+      assert :ok = acquire(pool)
+      assert {:ok, 0, 1} = status(pool)
+    end
+  end
+
+  describe "release/1" do
+    test "it increments the available concurrency in the pool when possible" do
+      pool = allocate_pool(16)
+      :ok = acquire(pool)
+      assert {:ok, 15, 16} = status(pool)
+      assert :ok = release(pool)
+      assert {:ok, 16, 16} = status(pool)
+    end
+
+    test "it doesn't allow the pool to grow" do
+      pool = allocate_pool(16)
+      assert {:ok, 16, 16} = status(pool)
+      assert :ok = release(pool)
+      assert {:ok, 16, 16} = status(pool)
+    end
+  end
+end

--- a/test/reactor/step/compose_test.exs
+++ b/test/reactor/step/compose_test.exs
@@ -1,7 +1,7 @@
 defmodule Reactor.Step.ComposeTest do
   @moduledoc false
   use ExUnit.Case, async: true
-  alias Reactor.{Argument, Step}
+  alias Reactor.{Argument, Executor.ConcurrencyTracker, Step}
   import Reactor.Builder
   require Reactor.Argument
 
@@ -31,6 +31,7 @@ defmodule Reactor.Step.ComposeTest do
                  %{whom: "Marty McFly"},
                  %{
                    current_step: %{name: :greet_marty},
+                   concurrency_key: ConcurrencyTracker.allocate_pool(16),
                    private: %{composed_reactors: MapSet.new([inner_reactor.id])}
                  },
                  reactor: inner_reactor


### PR DESCRIPTION
We use an atomic counter implemented with ETS to keep track of the number of available concurrency slots for a given key.  That key can be explicitly passed into a Reactor, or allocated directly by a Reactor.  This gives users the option to share concurrency limits across Reactors, or not at their own discretion.