### PR TITLE
improvement: Add "subpaths" to templates.

### DIFF
--- a/lib/reactor/argument.ex
+++ b/lib/reactor/argument.ex
@@ -88,4 +88,10 @@ defmodule Reactor.Argument do
   Validate that the argument has a transform.
   """
   defguard has_transform(argument) when is_transform(argument.transform)
+
+  @doc """
+  Validate that the argument source has a sub_path
+  """
+  defguard has_sub_path(argument)
+           when is_list(argument.source.sub_path) and argument.source.sub_path != []
 end

--- a/lib/reactor/dsl.ex
+++ b/lib/reactor/dsl.ex
@@ -67,12 +67,18 @@ defmodule Reactor.Dsl do
       argument :name, input(:name)
       """,
       """
+      argument :year, input(:date, [:year])
+      """,
+      """
       argument :user, result(:create_user)
       """,
       """
       argument :user_id, result(:create_user) do
         transform & &1.id
       end
+      """,
+      """
+      argument :user_id, result(:create_user, [:id])
       """,
       """
       argument :three, value(3)

--- a/lib/reactor/dsl/argument.ex
+++ b/lib/reactor/dsl/argument.ex
@@ -40,11 +40,18 @@ defmodule Reactor.Dsl.Argument do
     end
   end
   ```
+
+  ## Extracting nested values
+
+  You can provide a list of keys to extract from a data structure, similar to
+  `Kernel.get_in/2` with the condition that the input value is either a struct
+  or implements the `Access` protocol.
   """
-  @spec input(atom) :: Template.Input.t()
-  def input(input_name) do
-    %Template.Input{name: input_name}
-  end
+  @spec input(atom, [any]) :: Template.Input.t()
+  def input(input_name, sub_path \\ [])
+
+  def input(input_name, sub_path),
+    do: %Template.Input{name: input_name, sub_path: List.wrap(sub_path)}
 
   @doc ~S"""
   The `result` template helper for the Reactor DSL.
@@ -71,11 +78,18 @@ defmodule Reactor.Dsl.Argument do
     end
   end
   ```
+
+  ## Extracting nested values
+
+  You can provide a list of keys to extract from a data structure, similar to
+  `Kernel.get_in/2` with the condition that the result is either a struct or
+  implements the `Access` protocol.
   """
-  @spec result(atom) :: Template.Result.t()
-  def result(link_name) do
-    %Template.Result{name: link_name}
-  end
+  @spec result(atom, [any]) :: Template.Result.t()
+  def result(step_name, sub_path \\ [])
+
+  def result(step_name, sub_path),
+    do: %Template.Result{name: step_name, sub_path: List.wrap(sub_path)}
 
   @doc ~S"""
   The `value` template helper for the Reactor DSL.
@@ -101,9 +115,7 @@ defmodule Reactor.Dsl.Argument do
   ```
   """
   @spec value(any) :: Template.Value.t()
-  def value(value) do
-    %Template.Value{value: value}
-  end
+  def value(value), do: %Template.Value{value: value}
 
   defimpl Argument.Build do
     def build(argument) do

--- a/lib/reactor/template/input.ex
+++ b/lib/reactor/template/input.ex
@@ -3,7 +3,7 @@ defmodule Reactor.Template.Input do
   The `input` template.
   """
 
-  defstruct name: nil
+  defstruct name: nil, sub_path: []
 
-  @type t :: %__MODULE__{name: atom}
+  @type t :: %__MODULE__{name: atom, sub_path: [atom]}
 end

--- a/lib/reactor/template/result.ex
+++ b/lib/reactor/template/result.ex
@@ -3,7 +3,7 @@ defmodule Reactor.Template.Result do
   The `result` template.
   """
 
-  defstruct name: nil
+  defstruct name: nil, sub_path: []
 
-  @type t :: %__MODULE__{name: atom}
+  @type t :: %__MODULE__{name: atom, sub_path: [atom]}
 end


### PR DESCRIPTION
Allows you to specify a list of keys within a structure to extract in a similar manner to `Kernel.get_in/2`, except that structs are treated as maps.
