### PR TITLE
fix: Don't swallow errors when a step runs out of retries.

### DIFF
--- a/lib/reactor/errors/retries_exceeded_error.ex
+++ b/lib/reactor/errors/retries_exceeded_error.ex
@@ -1,0 +1,27 @@
+defmodule Reactor.Error.RetriesExceededError do
+  @moduledoc """
+  An error used when a step runs out of retry events and no other error is
+  thrown.
+  """
+  defexception [:step, :retry_count]
+
+  @doc false
+  @impl true
+  def exception(attrs), do: struct(__MODULE__, attrs)
+
+  @doc false
+  @impl true
+  def message(error) do
+    """
+    # Maximum number of retries exceeded executing step.
+
+    ## `retry_count`:
+
+    #{inspect(error.retry_count)}
+
+    ## `step`:
+
+    #{inspect(error.step)}
+    """
+  end
+end

--- a/lib/reactor/executor.ex
+++ b/lib/reactor/executor.ex
@@ -166,7 +166,7 @@ defmodule Reactor.Executor do
   defp handle_undo(_reactor, state, []), do: {:error, state.errors}
 
   defp handle_undo(reactor, state, [{step, value} | tail]) do
-    case Executor.StepRunner.undo(reactor, step, value, state.concurrency_key) do
+    case Executor.StepRunner.undo(reactor, state, step, value, state.concurrency_key) do
       :ok -> handle_undo(reactor, state, tail)
       {:error, reason} -> handle_undo(reactor, %{state | errors: [reason | state.errors]}, tail)
     end

--- a/test/reactor/executor/async_test.exs
+++ b/test/reactor/executor/async_test.exs
@@ -1,5 +1,5 @@
 defmodule Reactor.Executor.AsyncTest do
-  alias Reactor.Executor
+  alias Reactor.{Error, Executor}
   import Reactor.Executor.Async
   use ExUnit.Case, async: true
 
@@ -230,7 +230,9 @@ defmodule Reactor.Executor.AsyncTest do
          %{reactor: reactor, state: state, undoable: undoable, supervisor: supervisor} do
       task = Task.Supervisor.async_nolink(supervisor, fn -> :retry end)
       state = %{state | current_tasks: %{task => undoable}, retries: %{undoable.ref => 100}}
-      assert {:undo, _reactor, _state} = handle_completed_steps(reactor, state)
+
+      assert {:undo, _reactor, %{errors: [%Error.RetriesExceededError{}]}} =
+               handle_completed_steps(reactor, state)
     end
   end
 end

--- a/test/reactor/executor/sync_test.exs
+++ b/test/reactor/executor/sync_test.exs
@@ -1,5 +1,5 @@
 defmodule Reactor.Executor.SyncTest do
-  alias Reactor.Executor
+  alias Reactor.{Error, Executor}
   import Reactor.Executor.Sync
   use ExUnit.Case, async: true
   use Mimic
@@ -77,7 +77,7 @@ defmodule Reactor.Executor.SyncTest do
       |> stub(:run, fn _, _, _ -> :retry end)
 
       state = %{state | retries: Map.put(state.retries, step.ref, 100)}
-      assert {:undo, _, _} = run(reactor, state, step)
+      assert {:undo, _, %{errors: [%Error.RetriesExceededError{}]}} = run(reactor, state, step)
     end
 
     test "when the step is successful it tells the reactor to recurse", %{


### PR DESCRIPTION
When a step runs out of retry attempts we either use the error supplied, or synthesise a new one.
