### PR TITLE
Fix switch statements missing a default branch

### DIFF
--- a/lib/reactor/dsl/switch.ex
+++ b/lib/reactor/dsl/switch.ex
@@ -155,7 +155,13 @@ defmodule Reactor.Dsl.Switch do
     def verify(switch, dsl_state) do
       switch.matches
       |> Enum.flat_map(& &1.steps)
-      |> Enum.concat(switch.default.steps)
+      |> Enum.concat(
+        if is_nil(switch.default) do
+          []
+        else
+          switch.default.steps
+        end
+      )
       |> Enum.reduce_while(:ok, fn step, :ok ->
         case Build.verify(step, dsl_state) do
           :ok -> {:cont, :ok}

--- a/test/reactor/dsl/switch_test.exs
+++ b/test/reactor/dsl/switch_test.exs
@@ -34,11 +34,30 @@ defmodule Reactor.Dsl.SwitchTest do
     return :is_truthy?
   end
 
+  defmodule SwitchNoDefaultReactor do
+    @moduledoc false
+    use Reactor
+
+    input :value
+
+    switch :is_nil? do
+      on input(:value)
+
+      matches? &is_nil/1 do
+        step :falsy, Noop
+      end
+    end
+  end
+
   test "when provided a falsy value it works" do
     assert {:ok, :falsy} = Reactor.run(SwitchReactor, value: nil)
   end
 
   test "when provided a truthy value it works" do
     assert {:ok, :truthy} = Reactor.run(SwitchReactor, value: :marty)
+  end
+
+  test "it does not require a default" do
+    assert {:ok, nil} = Reactor.run(SwitchNoDefaultReactor, value: nil)
   end
 end


### PR DESCRIPTION
Relates to #127 

~~Currently this is just adding a failing test for when one does not add a default to a switch. Happy to try and fix the issue as well, but this will be my first time debugging Spark DSLs so I may need a bit of guidance.~~

I found the issue and this PR now both adds a test as well as the fix. I also tried following the conventional commits, but please let me know if you would like me to update anything.

# Contributor checklist

- [X] Bug fixes include regression tests
