### PR TITLE
Add missing `fn` in docs

### DIFF
--- a/documentation/dsls/DSL:-Reactor.md
+++ b/documentation/dsls/DSL:-Reactor.md
@@ -1058,7 +1058,7 @@ map :double_numbers do
   step :double do
     argument :number, element(:double_numbers)
 
-    run %{number: number}, _, _ ->
+    run fn %{number: number}, _, _ ->
       {:ok, number * 2}
     end
   end
@@ -1068,7 +1068,7 @@ end
 
 ```
 step :get_subscriptions do
-  run _, _, _ ->
+  run fn _, _, _ ->
     Stripe.Subscription.list()
   end
 end

--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -62,7 +62,7 @@ defmodule Reactor.Dsl.Map do
           step :double do
             argument :number, element(:double_numbers)
 
-            run %{number: number}, _, _ ->
+            run fn %{number: number}, _, _ ->
               {:ok, number * 2}
             end
           end
@@ -70,7 +70,7 @@ defmodule Reactor.Dsl.Map do
         """,
         """
         step :get_subscriptions do
-          run _, _, _ ->
+          run fn _, _, _ ->
             Stripe.Subscription.list()
           end
         end


### PR DESCRIPTION
As someone new to Elixir / Ash this caught me as I thought this may have been proper syntax. Only after a bit of digging I realized the docs where just missing the `fn` symbol.

# Contributor checklist

- [X] Documentation changes

