### PR TITLE
Fix docs around run

### DIFF
--- a/documentation/dsls/DSL:-Reactor.md
+++ b/documentation/dsls/DSL:-Reactor.md
@@ -1058,7 +1058,7 @@ map :double_numbers do
   step :double do
     argument :number, element(:double_numbers)
 
-    run fn %{number: number}, _, _ ->
+    run fn %{number: number}, _ ->
       {:ok, number * 2}
     end
   end
@@ -1068,7 +1068,7 @@ end
 
 ```
 step :get_subscriptions do
-  run fn _, _, _ ->
+  run fn _, _ ->
     Stripe.Subscription.list()
   end
 end
@@ -1079,7 +1079,7 @@ map :cancel_subscriptions do
   step :cancel do
     argument :sub_id, element(:cancel_subscriptions, [:id])
 
-    run fn args, _, _ ->
+    run fn args, _ ->
       Stripe.Subscription.cancel(arg.sub_id, %{prorate: true, invoice_now: true})
     end
   end
@@ -1272,10 +1272,10 @@ end
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`run`](#reactor-step-run){: #reactor-step-run } | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide an anonymous function which implements the `run/3` callback. Cannot be provided at the same time as the `impl` argument. |
-| [`undo`](#reactor-step-undo){: #reactor-step-undo } | `(any -> any) \| mfa \| (any, any -> any) \| mfa \| (any, any, any -> any) \| mfa` |  | Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument. |
-| [`compensate`](#reactor-step-compensate){: #reactor-step-compensate } | `(any -> any) \| mfa \| (any, any -> any) \| mfa \| (any, any, any -> any) \| mfa` |  | Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument. |
-| [`max_retries`](#reactor-step-max_retries){: #reactor-step-max_retries } | `:infinity \| non_neg_integer` | `:infinity` | The maximum number of times that the step can be retried before failing. Only used when the result of the `compensate/4` callback is `:retry`. |
+| [`run`](#reactor-step-run){: #reactor-step-run } | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide an anonymous function which implements a `run/1-2` callback. Cannot be provided at the same time as the `impl` argument. |
+| [`undo`](#reactor-step-undo){: #reactor-step-undo } | `(any -> any) \| mfa \| (any, any -> any) \| mfa \| (any, any, any -> any) \| mfa` |  | Provide an anonymous function which implements a `undo/1-3` callback. Cannot be provided at the same time as the `impl` argument. |
+| [`compensate`](#reactor-step-compensate){: #reactor-step-compensate } | `(any -> any) \| mfa \| (any, any -> any) \| mfa \| (any, any, any -> any) \| mfa` |  | Provide an anonymous function which implements a `compensate/1-3` callback. Cannot be provided at the same time as the `impl` argument. |
+| [`max_retries`](#reactor-step-max_retries){: #reactor-step-max_retries } | `:infinity \| non_neg_integer` | `:infinity` | The maximum number of times that the step can be retried before failing. Only used when the result of the `compensate` callback is `:retry`. |
 | [`async?`](#reactor-step-async?){: #reactor-step-async? } | `boolean` | `true` | When set to true the step will be executed asynchronously via Reactor's `TaskSupervisor`. |
 | [`transform`](#reactor-step-transform){: #reactor-step-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the entire argument map before it is passed to the step. |
 

--- a/lib/reactor/dsl/argument.ex
+++ b/lib/reactor/dsl/argument.ex
@@ -63,7 +63,7 @@ defmodule Reactor.Dsl.Argument do
     use Reactor
 
     step :whom do
-      run fn ->
+      run fn _, _ ->
         {:ok, Enum.random(["Marty", "Doc", "Jennifer", "Lorraine", "George", nil])}
       end
     end
@@ -107,7 +107,7 @@ defmodule Reactor.Dsl.Argument do
       # here: -------↓↓↓↓↓
       argument :rhs, value(3)
 
-      run fn args, _, _ ->
+      run fn args, _ ->
         {:ok, args.lhs * args.rhs}
       end
     end
@@ -134,7 +134,7 @@ defmodule Reactor.Dsl.Argument do
       step :double do
         argument :number, element(:double_numbers)
 
-        run fn args, _, _ ->
+        run fn args, _ ->
           {:ok, args.number * 2}
         end
       end

--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -62,7 +62,7 @@ defmodule Reactor.Dsl.Map do
           step :double do
             argument :number, element(:double_numbers)
 
-            run fn %{number: number}, _, _ ->
+            run fn %{number: number}, _ ->
               {:ok, number * 2}
             end
           end
@@ -70,7 +70,7 @@ defmodule Reactor.Dsl.Map do
         """,
         """
         step :get_subscriptions do
-          run fn _, _, _ ->
+          run fn _, _ ->
             Stripe.Subscription.list()
           end
         end
@@ -81,7 +81,7 @@ defmodule Reactor.Dsl.Map do
           step :cancel do
             argument :sub_id, element(:cancel_subscriptions, [:id])
 
-            run fn args, _, _ ->
+            run fn args, _ ->
               Stripe.Subscription.cancel(arg.sub_id, %{prorate: true, invoice_now: true})
             end
           end

--- a/lib/reactor/dsl/step.ex
+++ b/lib/reactor/dsl/step.ex
@@ -90,21 +90,21 @@ defmodule Reactor.Dsl.Step do
           type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}]},
           required: false,
           doc: """
-          Provide an anonymous function which implements the `run/3` callback. Cannot be provided at the same time as the `impl` argument.
+          Provide an anonymous function which implements a `run/1-2` callback. Cannot be provided at the same time as the `impl` argument.
           """
         ],
         undo: [
           type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}, {:mfa_or_fun, 3}]},
           required: false,
           doc: """
-          Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument.
+          Provide an anonymous function which implements a `undo/1-3` callback. Cannot be provided at the same time as the `impl` argument.
           """
         ],
         compensate: [
           type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}, {:mfa_or_fun, 3}]},
           required: false,
           doc: """
-          Provide an anonymous function which implements the `undo/4` callback. Cannot be provided at the same time as the `impl` argument.
+          Provide an anonymous function which implements a `compensate/1-3` callback. Cannot be provided at the same time as the `impl` argument.
           """
         ],
         max_retries: [
@@ -112,7 +112,7 @@ defmodule Reactor.Dsl.Step do
           required: false,
           default: :infinity,
           doc: """
-          The maximum number of times that the step can be retried before failing. Only used when the result of the `compensate/4` callback is `:retry`.
+          The maximum number of times that the step can be retried before failing. Only used when the result of the `compensate` callback is `:retry`.
           """
         ],
         async?: [

--- a/test/reactor/step/anon_fn_test.exs
+++ b/test/reactor/step/anon_fn_test.exs
@@ -7,7 +7,7 @@ defmodule Reactor.Step.AnonFnTest do
     assert Spark.implements_behaviour?(Reactor.Step.AnonFn, Reactor.Step)
   end
 
-  describe "run/3" do
+  describe "run/2" do
     test "it can handle 2 arity anonymous functions" do
       fun = fn arguments, _ ->
         arguments.first_name

--- a/test/reactor/step/transform_test.exs
+++ b/test/reactor/step/transform_test.exs
@@ -9,8 +9,8 @@ defmodule Reactor.Step.TransformTest do
 
   describe "run/3" do
     test "when the value argument is missing" do
-      assert {:error, error} = run(%{}, %{current_step: :current_step}, [])
-      assert Exception.message(error) =~ "argument is missing"
+      assert {:error, error} = run(%{}, %{current_step: %{name: :current_step}}, [])
+      assert Exception.message(error) =~ "Missing Argument Error"
     end
 
     test "it applies the transform" do


### PR DESCRIPTION
This PR fixes #128 and a small test that was warning. It mostly focuses on correcting the documentation around how the anonymous `run` function should be used within a step.

# Contributor checklist

- [X] Bug fixes include regression tests
- [X] Documentation changes

