### PR TITLE
feat: Add step guards.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -26,6 +26,8 @@ spark_locals_without_parens = [
   fun: 1,
   group: 1,
   group: 2,
+  guard: 1,
+  guard: 2,
   impl: 1,
   input: 1,
   input: 2,
@@ -50,7 +52,9 @@ spark_locals_without_parens = [
   transform: 1,
   undo: 1,
   wait_for: 1,
-  wait_for: 2
+  wait_for: 2,
+  where: 1,
+  where: 2
 ]
 
 [

--- a/documentation/dsls/DSL-Reactor.md
+++ b/documentation/dsls/DSL-Reactor.md
@@ -14,28 +14,44 @@ The top-level reactor DSL
  * [around](#reactor-around)
    * argument
    * wait_for
+   * where
+   * guard
  * [collect](#reactor-collect)
    * argument
    * wait_for
+   * where
+   * guard
  * [compose](#reactor-compose)
    * argument
    * wait_for
+   * where
+   * guard
  * [debug](#reactor-debug)
    * argument
    * wait_for
+   * where
+   * guard
  * [flunk](#reactor-flunk)
    * argument
    * wait_for
+   * where
+   * guard
  * [group](#reactor-group)
    * argument
    * wait_for
+   * where
+   * guard
  * [input](#reactor-input)
  * [map](#reactor-map)
    * argument
    * wait_for
+   * where
+   * guard
  * [step](#reactor-step)
    * argument
    * wait_for
+   * where
+   * guard
  * [switch](#reactor-switch)
    * matches?
 
@@ -108,6 +124,8 @@ Wrap a function around a group of steps.
 ### Nested DSLs
  * [argument](#reactor-around-argument)
  * [wait_for](#reactor-around-wait_for)
+ * [where](#reactor-around-where)
+ * [guard](#reactor-around-guard)
 
 
 
@@ -237,6 +255,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.around.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-around-where-predicate){: #reactor-around-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-around-where-description){: #reactor-around-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.around.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-around-guard-fun){: #reactor-around-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-around-guard-description){: #reactor-around-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -258,6 +372,8 @@ Arguments can optionally be transformed before returning.
 ### Nested DSLs
  * [argument](#reactor-collect-argument)
  * [wait_for](#reactor-collect-wait_for)
+ * [where](#reactor-collect-where)
+ * [guard](#reactor-collect-guard)
 
 
 ### Examples
@@ -399,6 +515,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.collect.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-collect-where-predicate){: #reactor-collect-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-collect-where-description){: #reactor-collect-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.collect.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-collect-guard-fun){: #reactor-collect-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-collect-guard-description){: #reactor-collect-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -420,6 +632,8 @@ Allows place another Reactor into this one as if it were a single step.
 ### Nested DSLs
  * [argument](#reactor-compose-argument)
  * [wait_for](#reactor-compose-wait_for)
+ * [where](#reactor-compose-where)
+ * [guard](#reactor-compose-guard)
 
 
 
@@ -548,6 +762,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.compose.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-compose-where-predicate){: #reactor-compose-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-compose-where-description){: #reactor-compose-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.compose.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-compose-guard-fun){: #reactor-compose-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-compose-guard-description){: #reactor-compose-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -567,6 +877,8 @@ Inserts a step which will send debug information to the `Logger`.
 ### Nested DSLs
  * [argument](#reactor-debug-argument)
  * [wait_for](#reactor-debug-wait_for)
+ * [where](#reactor-debug-where)
+ * [guard](#reactor-debug-guard)
 
 
 ### Examples
@@ -702,6 +1014,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.debug.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-debug-where-predicate){: #reactor-debug-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-debug-where-description){: #reactor-debug-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.debug.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-debug-guard-fun){: #reactor-debug-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-debug-guard-description){: #reactor-debug-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -724,6 +1132,8 @@ Additionally, any arguments to the step will be stored in the exception under th
 ### Nested DSLs
  * [argument](#reactor-flunk-argument)
  * [wait_for](#reactor-flunk-wait_for)
+ * [where](#reactor-flunk-where)
+ * [guard](#reactor-flunk-guard)
 
 
 ### Examples
@@ -858,6 +1268,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.flunk.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-flunk-where-predicate){: #reactor-flunk-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-flunk-where-description){: #reactor-flunk-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.flunk.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-flunk-guard-fun){: #reactor-flunk-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-flunk-guard-description){: #reactor-flunk-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -877,6 +1383,8 @@ Call functions before and after a group of steps.
 ### Nested DSLs
  * [argument](#reactor-group-argument)
  * [wait_for](#reactor-group-wait_for)
+ * [where](#reactor-group-where)
+ * [guard](#reactor-group-guard)
 
 
 
@@ -1007,6 +1515,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.group.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-group-where-predicate){: #reactor-group-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-group-where-description){: #reactor-group-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.group.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-group-guard-fun){: #reactor-group-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-group-guard-description){: #reactor-group-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -1094,6 +1698,8 @@ is implemented.
 ### Nested DSLs
  * [argument](#reactor-map-argument)
  * [wait_for](#reactor-map-wait_for)
+ * [where](#reactor-map-where)
+ * [guard](#reactor-map-guard)
 
 
 ### Examples
@@ -1265,6 +1871,102 @@ wait_for :create_user
 
 Target: `Reactor.Dsl.WaitFor`
 
+## reactor.map.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-map-where-predicate){: #reactor-map-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-map-where-description){: #reactor-map-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.map.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-map-guard-fun){: #reactor-map-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-map-guard-description){: #reactor-map-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
+
 
 
 
@@ -1290,6 +1992,8 @@ See the `Reactor.Step` behaviour for more information.
 ### Nested DSLs
  * [argument](#reactor-step-argument)
  * [wait_for](#reactor-step-wait_for)
+ * [where](#reactor-step-where)
+ * [guard](#reactor-step-guard)
 
 
 ### Examples
@@ -1443,6 +2147,102 @@ wait_for :create_user
 ### Introspection
 
 Target: `Reactor.Dsl.WaitFor`
+
+## reactor.step.where
+```elixir
+where predicate
+```
+
+
+Only execute the surrounding step if the predicate function returns true.
+
+This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+
+
+
+
+### Examples
+```
+step :read_file do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  where &File.exists?(&1.path)
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`predicate`](#reactor-step-where-predicate){: #reactor-step-where-predicate .spark-required} | `(any -> any) \| mfa \| (any, any -> any) \| mfa` |  | Provide a function which takes the step arguments and optionally the context and returns a boolean value. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-step-where-description){: #reactor-step-where-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Where`
+
+## reactor.step.guard
+```elixir
+guard fun
+```
+
+
+Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+- `:cont` - the guard has passed.
+- `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+
+
+
+
+### Examples
+```
+step :read_file_via_cache do
+  argument :path, input(:path)
+  run &File.read(&1.path)
+  guard fn %{path: path}, %{cache: cache} ->
+    case Cache.get(cache, path) do
+      {:ok, content} -> {:halt, {:ok, content}}
+      _ -> :cont
+    end
+  end
+end
+
+```
+
+
+
+### Arguments
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`fun`](#reactor-step-guard-fun){: #reactor-step-guard-fun .spark-required} | `(any, any -> any) \| mfa` |  | The guard function. |
+### Options
+
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`description`](#reactor-step-guard-description){: #reactor-step-guard-description } | `String.t` |  | An optional description of the guard. |
+
+
+
+
+
+### Introspection
+
+Target: `Reactor.Dsl.Guard`
 
 
 

--- a/lib/reactor/argument/build.ex
+++ b/lib/reactor/argument/build.ex
@@ -6,7 +6,7 @@ defprotocol Reactor.Argument.Build do
   alias Reactor.Argument
 
   @doc """
-  Convert the input into an argument.
+  Convert the input into one or more arguments.
   """
   @spec build(t) :: {:ok, [Argument.t()]} | {:error, any}
   def build(input)

--- a/lib/reactor/dsl/around.ex
+++ b/lib/reactor/dsl/around.ex
@@ -9,6 +9,7 @@ defmodule Reactor.Dsl.Around do
             arguments: [],
             description: nil,
             fun: nil,
+            guards: [],
             name: nil,
             steps: []
 
@@ -20,6 +21,7 @@ defmodule Reactor.Dsl.Around do
           arguments: [Dsl.Argument.t()],
           description: nil | String.t(),
           fun: mfa | Step.Around.around_fun(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           name: atom,
           steps: [Dsl.Step.t()]
         }
@@ -34,7 +36,11 @@ defmodule Reactor.Dsl.Around do
       target: Dsl.Around,
       args: [:name, {:optional, :fun}],
       identifier: :name,
-      entities: [steps: [], arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        steps: [],
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -85,6 +91,7 @@ defmodule Reactor.Dsl.Around do
            steps: sub_reactor.steps, fun: around.fun, allow_async?: around.allow_async?},
           around.arguments,
           async?: around.allow_async?,
+          guards: around.guards,
           max_retries: 0,
           ref: :step_name
         )

--- a/lib/reactor/dsl/collect.ex
+++ b/lib/reactor/dsl/collect.ex
@@ -8,6 +8,7 @@ defmodule Reactor.Dsl.Collect do
   defstruct __identifier__: nil,
             arguments: [],
             description: nil,
+            guards: [],
             name: nil,
             transform: nil
 
@@ -16,6 +17,7 @@ defmodule Reactor.Dsl.Collect do
   @type t :: %__MODULE__{
           arguments: [Dsl.Argument.t()],
           description: nil | String.t(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           name: atom,
           transform: nil | (any -> any),
           __identifier__: any
@@ -45,7 +47,10 @@ defmodule Reactor.Dsl.Collect do
       args: [:name],
       target: __MODULE__,
       identifier: :name,
-      entities: [arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -81,6 +86,7 @@ defmodule Reactor.Dsl.Collect do
         Step.ReturnAllArguments,
         collect.arguments,
         async?: true,
+        guards: collect.guards,
         max_retries: 1,
         transform: collect.transform,
         ref: :step_name

--- a/lib/reactor/dsl/compose.ex
+++ b/lib/reactor/dsl/compose.ex
@@ -4,7 +4,12 @@ defmodule Reactor.Dsl.Compose do
 
   See the `d:Reactor.compose`.
   """
-  defstruct __identifier__: nil, description: nil, arguments: [], name: nil, reactor: nil
+  defstruct __identifier__: nil,
+            arguments: [],
+            description: nil,
+            guards: [],
+            name: nil,
+            reactor: nil
 
   alias Reactor.{Builder, Dsl}
 
@@ -12,6 +17,7 @@ defmodule Reactor.Dsl.Compose do
           __identifier__: any,
           arguments: [Dsl.Argument.t()],
           description: nil | String.t(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           name: any,
           reactor: module | Reactor.t()
         }
@@ -29,7 +35,10 @@ defmodule Reactor.Dsl.Compose do
       target: Dsl.Compose,
       identifier: :name,
       no_depend_modules: [:reactor],
-      entities: [arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -58,7 +67,9 @@ defmodule Reactor.Dsl.Compose do
 
   defimpl Dsl.Build do
     def build(compose, reactor) do
-      Builder.compose(reactor, compose.name, compose.reactor, compose.arguments)
+      Builder.compose(reactor, compose.name, compose.reactor, compose.arguments,
+        guards: compose.guards
+      )
     end
 
     def transform(_compose, dsl_state), do: {:ok, dsl_state}

--- a/lib/reactor/dsl/debug.ex
+++ b/lib/reactor/dsl/debug.ex
@@ -7,14 +7,16 @@ defmodule Reactor.Dsl.Debug do
 
   defstruct __identifier__: nil,
             arguments: [],
+            guards: [],
             level: :debug,
             name: nil
 
-  alias Reactor.{Dsl.Argument, Dsl.Build, Dsl.Debug, Dsl.WaitFor}
+  alias Reactor.Dsl.{Argument, Build, Debug, Guard, WaitFor, Where}
 
   @type t :: %Debug{
           __identifier__: any,
           arguments: [Argument.t()],
+          guards: [Where.t() | Guard.t()],
           level: Logger.level(),
           name: atom
         }
@@ -36,7 +38,10 @@ defmodule Reactor.Dsl.Debug do
       target: Debug,
       args: [:name],
       identifier: :name,
-      entities: [arguments: [Argument.__entity__(), WaitFor.__entity__()]],
+      entities: [
+        arguments: [Argument.__entity__(), WaitFor.__entity__()],
+        guards: [Where.__entity__(), Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -66,6 +71,7 @@ defmodule Reactor.Dsl.Debug do
         debug.name,
         {Step.Debug, level: debug.level},
         debug.arguments,
+        guards: debug.guards,
         max_retries: 0,
         ref: :step_name
       )

--- a/lib/reactor/dsl/flunk.ex
+++ b/lib/reactor/dsl/flunk.ex
@@ -5,11 +5,21 @@ defmodule Reactor.Dsl.Flunk do
   See `d:Reactor.flunk`.
   """
 
-  alias Reactor.{Dsl.Argument, Dsl.Build, Dsl.Flunk, Dsl.WaitFor, Step, Template}
+  alias Reactor.{
+    Dsl.Argument,
+    Dsl.Build,
+    Dsl.Flunk,
+    Dsl.Guard,
+    Dsl.WaitFor,
+    Dsl.Where,
+    Step,
+    Template
+  }
 
   defstruct __identifier__: nil,
             arguments: [],
             description: nil,
+            guards: [],
             name: nil,
             message: nil
 
@@ -17,6 +27,7 @@ defmodule Reactor.Dsl.Flunk do
           __identifier__: any,
           arguments: [Argument.t()],
           description: nil | String.t(),
+          guards: [Where.t() | Guard.t()],
           message: Template.t(),
           name: atom
         }
@@ -38,7 +49,10 @@ defmodule Reactor.Dsl.Flunk do
       ],
       args: [:name, :message],
       target: __MODULE__,
-      entities: [arguments: [Argument.__entity__(), WaitFor.__entity__()]],
+      entities: [
+        arguments: [Argument.__entity__(), WaitFor.__entity__()],
+        guards: [Where.__entity__(), Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -78,6 +92,7 @@ defmodule Reactor.Dsl.Flunk do
                {flunk.name, :arguments},
                Step.ReturnAllArguments,
                flunk.arguments,
+               guards: flunk.guards,
                async?: true,
                max_retries: 1,
                ref: :step_name

--- a/lib/reactor/dsl/group.ex
+++ b/lib/reactor/dsl/group.ex
@@ -10,6 +10,7 @@ defmodule Reactor.Dsl.Group do
             arguments: [],
             before_all: nil,
             description: nil,
+            guards: [],
             name: nil,
             steps: []
 
@@ -22,6 +23,7 @@ defmodule Reactor.Dsl.Group do
           arguments: [Dsl.Argument.t()],
           before_all: mfa | Step.Group.before_fun(),
           description: nil | String.t(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           name: atom,
           steps: [Dsl.Step.t()]
         }
@@ -36,7 +38,11 @@ defmodule Reactor.Dsl.Group do
       target: Dsl.Group,
       args: [:name],
       identifier: :name,
-      entities: [steps: [], arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()],
+        steps: []
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -97,6 +103,7 @@ defmodule Reactor.Dsl.Group do
            allow_async?: group.allow_async?},
           group.arguments,
           async?: group.allow_async?,
+          guards: group.guards,
           max_retries: 0,
           ref: :step_name
         )

--- a/lib/reactor/dsl/guard.ex
+++ b/lib/reactor/dsl/guard.ex
@@ -1,0 +1,70 @@
+defmodule Reactor.Dsl.Guard do
+  @moduledoc """
+  A struct used to store the `guard` DSL entity.
+
+  See `d:Reactor.step.guard`
+  """
+
+  defstruct __identifier__: nil, description: nil, fun: nil
+
+  alias Reactor.Guard
+
+  @type t :: %__MODULE__{
+          __identifier__: any,
+          description: nil | String.t(),
+          fun: (Reactor.inputs(), Reactor.context() -> :cont | {:halt, Reactor.Step.run_result()})
+        }
+
+  @doc false
+  def __entity__,
+    do: %Spark.Dsl.Entity{
+      name: :guard,
+      describe: """
+      Provides a flexible method for conditionally executing a step, or replacing it's result.
+
+      Expects a two arity function which takes the step's arguments and context and returns one of the following:
+
+      - `:cont` - the guard has passed.
+      - `{:halt, result}` - the guard has failed - instead of executing the step use the provided result.
+      """,
+      examples: [
+        """
+        step :read_file_via_cache do
+          argument :path, input(:path)
+          run &File.read(&1.path)
+          guard fn %{path: path}, %{cache: cache} ->
+            case Cache.get(cache, path) do
+              {:ok, content} -> {:halt, {:ok, content}}
+              _ -> :cont
+            end
+          end
+        end
+        """
+      ],
+      args: [:fun],
+      target: __MODULE__,
+      schema: [
+        fun: [
+          type: {:mfa_or_fun, 2},
+          required: true,
+          doc: """
+          The guard function.
+          """
+        ],
+        description: [
+          type: :string,
+          required: false,
+          doc: """
+          An optional description of the guard.
+          """
+        ]
+      ]
+    }
+
+  defimpl Guard.Build do
+    @doc false
+    def build(guard) do
+      {:ok, [%Guard{fun: guard.fun}]}
+    end
+  end
+end

--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -10,6 +10,7 @@ defmodule Reactor.Dsl.Map do
             arguments: [],
             batch_size: 100,
             description: nil,
+            guards: [],
             iterable?: true,
             name: nil,
             return: nil,
@@ -25,6 +26,7 @@ defmodule Reactor.Dsl.Map do
           arguments: [Dsl.Argument.t()],
           batch_size: pos_integer(),
           description: nil | String.t(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           iterable?: true,
           name: atom,
           return: atom,
@@ -96,7 +98,11 @@ defmodule Reactor.Dsl.Map do
       args: [:name],
       identifier: :name,
       imports: [Dsl.Argument],
-      entities: [steps: [], arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()],
+        steps: []
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -189,6 +195,7 @@ defmodule Reactor.Dsl.Map do
           map.name,
           {Step.Map, step_options},
           arguments,
+          guards: map.guards,
           max_retries: 0,
           ref: :step_name
         )

--- a/lib/reactor/dsl/step.ex
+++ b/lib/reactor/dsl/step.ex
@@ -10,6 +10,7 @@ defmodule Reactor.Dsl.Step do
             async?: true,
             compensate: nil,
             description: nil,
+            guards: [],
             impl: nil,
             max_retries: :infinity,
             name: nil,
@@ -25,6 +26,7 @@ defmodule Reactor.Dsl.Step do
           compensate:
             nil | (any, Reactor.inputs(), Reactor.context() -> :ok | :retry | {:continue, any}),
           description: nil | String.t(),
+          guards: [Dsl.Where.t() | Dsl.Guard.t()],
           impl: module | {module, keyword},
           max_retries: non_neg_integer() | :infinity,
           name: atom,
@@ -71,7 +73,10 @@ defmodule Reactor.Dsl.Step do
       target: __MODULE__,
       identifier: :name,
       no_depend_modules: [:impl],
-      entities: [arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()]],
+      entities: [
+        arguments: [Dsl.Argument.__entity__(), Dsl.WaitFor.__entity__()],
+        guards: [Dsl.Where.__entity__(), Dsl.Guard.__entity__()]
+      ],
       recursive_as: :steps,
       schema: [
         name: [
@@ -150,6 +155,7 @@ defmodule Reactor.Dsl.Step do
       with {:ok, step} <- rewrite_step(step, reactor.id) do
         Builder.add_step(reactor, step.name, step.impl, step.arguments,
           async?: step.async?,
+          guards: step.guards,
           max_retries: step.max_retries,
           transform: step.transform,
           ref: :step_name

--- a/lib/reactor/dsl/where.ex
+++ b/lib/reactor/dsl/where.ex
@@ -1,0 +1,81 @@
+defmodule Reactor.Dsl.Where do
+  @moduledoc """
+  A struct used to store the `where` DSL entity.
+
+  See `d:Reactor.step.where`.
+  """
+
+  defstruct __identifier__: nil, description: nil, predicate: nil
+
+  alias Reactor.Guard
+
+  @type t :: %__MODULE__{
+          __identifier__: any,
+          description: nil | String.t(),
+          predicate:
+            (Reactor.inputs() -> boolean) | (Reactor.inputs(), Reactor.context() -> boolean)
+        }
+
+  @doc false
+  def __entity__,
+    do: %Spark.Dsl.Entity{
+      name: :where,
+      describe: """
+      Only execute the surrounding step if the predicate function returns true.
+
+      This is a simple version of `guard` which provides more flexibility at the cost of complexity.
+      """,
+      examples: [
+        """
+        step :read_file do
+          argument :path, input(:path)
+          run &File.read(&1.path)
+          where &File.exists?(&1.path)
+        end
+        """
+      ],
+      args: [:predicate],
+      target: __MODULE__,
+      schema: [
+        predicate: [
+          type: {:or, [{:mfa_or_fun, 1}, {:mfa_or_fun, 2}]},
+          required: true,
+          doc: """
+          Provide a function which takes the step arguments and optionally the context and returns a boolean value.
+          """
+        ],
+        description: [
+          type: :string,
+          required: false,
+          doc: """
+          An optional description of the guard.
+          """
+        ]
+      ]
+    }
+
+  @doc false
+  def eval(arguments, context, where) do
+    if eval_predicate(arguments, context, where) do
+      :cont
+    else
+      {:halt, {:ok, nil}}
+    end
+  end
+
+  defp eval_predicate(arguments, context, where) when is_function(where.predicate, 2),
+    do: where.predicate.(arguments, context)
+
+  defp eval_predicate(arguments, _context, where) when is_function(where.predicate, 1),
+    do: where.predicate.(arguments)
+
+  defimpl Guard.Build do
+    @doc false
+    def build(where) do
+      {:ok,
+       [
+         %Guard{fun: {Reactor.Dsl.Where, :eval, [where]}}
+       ]}
+    end
+  end
+end

--- a/lib/reactor/executor/state.ex
+++ b/lib/reactor/executor/state.ex
@@ -21,6 +21,7 @@ defmodule Reactor.Executor.State do
             max_iterations: @defaults.max_iterations,
             pool_owner: false,
             retries: %{},
+            skipped: MapSet.new(),
             started_at: nil,
             timeout: @defaults.timeout
 
@@ -36,6 +37,7 @@ defmodule Reactor.Executor.State do
           max_iterations: pos_integer() | :infinity,
           pool_owner: boolean,
           retries: %{reference() => pos_integer()},
+          skipped: MapSet.t(),
           started_at: DateTime.t(),
           timeout: pos_integer() | :infinity
         }

--- a/lib/reactor/guard.ex
+++ b/lib/reactor/guard.ex
@@ -1,0 +1,26 @@
+defmodule Reactor.Guard do
+  @moduledoc """
+  A Reactor guard.
+
+  Guard types should implement the `Reactor.Guard.Build` protocol.
+
+  This struct contains a single two arity function, which when called with a
+  step's arguments and context returns one of the following:
+
+  - `:cont` - this guard has passed - continue evaluating any additional guards
+    and if exhausted run the step.
+  - `{:halt, result}` - the guard has failed - use `result` as the steps result.
+  """
+
+  defstruct fun: nil
+
+  @type t :: %__MODULE__{
+          fun:
+            (Reactor.inputs(), Reactor.context() -> :cont | {:halt, Reactor.Step.run_result()})
+            | mfa
+        }
+
+  defimpl Reactor.Guard.Build do
+    def build(guard), do: {:ok, [guard]}
+  end
+end

--- a/lib/reactor/guard/build.ex
+++ b/lib/reactor/guard/build.ex
@@ -1,0 +1,13 @@
+defprotocol Reactor.Guard.Build do
+  @moduledoc """
+  A protocol which can be used to convert something into a guard.
+  """
+
+  alias Reactor.Guard
+
+  @doc """
+  Convert the input into one or more guards.
+  """
+  @spec build(t) :: {:ok, [Guard.t()]} | {:error, any}
+  def build(input)
+end

--- a/lib/reactor/middleware.ex
+++ b/lib/reactor/middleware.ex
@@ -29,6 +29,9 @@ defmodule Reactor.Middleware do
           | {:compensate_error, error_or_errors}
           | {:compensate_retry, any}
           | {:compensate_start, any}
+          | {:guard_start, Reactor.Guard.t(), arguments :: Reactor.inputs()}
+          | {:guard_fail, Reactor.Guard.t(), Reactor.Step.run_result()}
+          | {:guard_pass, Reactor.Guard.t()}
           | {:process_start, pid}
           | {:process_terminate, pid}
           | {:run_complete, result}

--- a/lib/reactor/step.ex
+++ b/lib/reactor/step.ex
@@ -13,20 +13,25 @@ defmodule Reactor.Step do
             name: nil,
             max_retries: :infinity,
             ref: nil,
-            transform: nil
+            transform: nil,
+            guards: []
 
   alias Reactor.{Argument, Step}
+
+  @type context :: %{optional(atom) => any}
+  @type arguments :: %{optional(atom) => any}
 
   @type t :: %Step{
           arguments: [Argument.t()],
           async?: boolean | (keyword -> boolean),
-          context: %{optional(atom) => any},
+          context: context(),
           description: nil | String.t(),
           impl: module | {module, keyword},
           name: any,
           max_retries: non_neg_integer() | :infinity,
           ref: nil | reference(),
-          transform: nil | (any -> any) | {module, keyword} | mfa
+          transform: nil | (any -> any) | {module, keyword} | mfa,
+          guards: [Reactor.Guard.t()]
         }
 
   @type step :: module

--- a/test/reactor/builder/compose_test.exs
+++ b/test/reactor/builder/compose_test.exs
@@ -38,7 +38,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:ok, reactor} =
                InnerReactor
                |> Builder.new()
-               |> Compose.compose(:recurse, InnerReactor, message: {:input, :message})
+               |> Compose.compose(:recurse, InnerReactor, [message: {:input, :message}], [])
 
       assert recurse_step =
                reactor.steps
@@ -59,7 +59,7 @@ defmodule Reactor.Builder.ComposeTest do
 
       assert {:ok, outer_reactor} =
                inner_reactor
-               |> Builder.compose(:recurse, inner_reactor, message: {:input, :message})
+               |> Builder.compose(:recurse, inner_reactor, [message: {:input, :message}], [])
 
       assert recurse_step =
                outer_reactor.steps
@@ -85,7 +85,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:ok, outer_reactor} =
                Builder.new()
                |> Builder.add_input!(:name)
-               |> Compose.compose(:shout_at, inner_reactor, message: {:input, :name})
+               |> Compose.compose(:shout_at, inner_reactor, [message: {:input, :name}], [])
 
       assert {:__reactor__, :compose, :shout_at, :shout} in Enum.map(
                outer_reactor.steps,
@@ -103,7 +103,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:ok, outer_reactor} =
                Builder.new()
                |> Builder.add_input!(:name)
-               |> Compose.compose(:shout_at, inner_reactor, message: {:input, :name})
+               |> Compose.compose(:shout_at, inner_reactor, [message: {:input, :name}], [])
 
       assert {:__reactor__, :compose, :shout_at, :shout} in Enum.map(
                outer_reactor.steps,
@@ -120,7 +120,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:error, %ComposeError{} = error} =
                Builder.new()
                |> Builder.add_input!(:name)
-               |> Compose.compose(:shout_at, inner_reactor, message: {:input, :name})
+               |> Compose.compose(:shout_at, inner_reactor, [message: {:input, :name}], [])
 
       assert Exception.message(error) =~ ~r/must have an explicit return value/i
     end
@@ -134,7 +134,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:error, %ArgumentError{} = error} =
                Builder.new()
                |> Builder.add_input!(:name)
-               |> Compose.compose(:shout_at, inner_reactor, [{:marty}])
+               |> Compose.compose(:shout_at, inner_reactor, [{:marty}], [])
 
       assert Exception.message(error) =~ ~r/contains a non-argument value/i
     end
@@ -148,7 +148,7 @@ defmodule Reactor.Builder.ComposeTest do
       assert {:error, %ComposeError{} = error} =
                Builder.new()
                |> Builder.add_input!(:name)
-               |> Compose.compose(:shout_at, inner_reactor, [])
+               |> Compose.compose(:shout_at, inner_reactor, [], [])
 
       assert Exception.message(error) =~ ~r/missing argument for `message` input/i
     end

--- a/test/reactor/builder/step_test.exs
+++ b/test/reactor/builder/step_test.exs
@@ -13,7 +13,7 @@ defmodule Reactor.Builder.StepTest do
     end
   end
 
-  describe "add_step/5" do
+  describe "add_step/6" do
     test "when given an invalid argument it returns an error" do
       reactor = Builder.new()
 
@@ -189,7 +189,7 @@ defmodule Reactor.Builder.StepTest do
     end
   end
 
-  describe "new_step/4" do
+  describe "new_step/5" do
     test "it builds a step" do
       assert {:ok, %Step{}} = Builder.Step.new_step(:marty, GreeterStep, [], [])
     end
@@ -200,7 +200,8 @@ defmodule Reactor.Builder.StepTest do
     end
 
     test "when the impl is not a `Reactor.Step` it returns an error" do
-      assert {:error, %ArgumentError{} = error} = Builder.Step.new_step(:greet, Kernel, [], [])
+      assert {:error, %ArgumentError{} = error} =
+               Builder.Step.new_step(:greet, Kernel, [], [])
 
       assert Exception.message(error) =~ ~r/does not implement the `Reactor.Step` behaviour/i
     end

--- a/test/reactor/builder_test.exs
+++ b/test/reactor/builder_test.exs
@@ -34,7 +34,7 @@ defmodule Reactor.BuilderTest do
     end
   end
 
-  describe "add_step/3..5" do
+  describe "add_step/3..6" do
     defmodule Noop do
       @moduledoc false
       use Reactor.Step

--- a/test/reactor/dsl/guard_test.exs
+++ b/test/reactor/dsl/guard_test.exs
@@ -1,0 +1,67 @@
+defmodule Reactor.Dsl.GuardTest do
+  use ExUnit.Case, async: true
+
+  setup context do
+    test_sig =
+      context
+      |> Map.take(~w[line module file test]a)
+      |> :erlang.phash2()
+      |> Integer.to_string(16)
+
+    base = System.tmp_dir!()
+
+    tmp_dir = Path.join(base, test_sig)
+    File.mkdir_p!(tmp_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_dir)
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  defmodule CachedReadReactor do
+    @moduledoc false
+    use Reactor
+
+    input :path
+
+    step :read do
+      argument :path, input(:path)
+
+      run fn args ->
+        {:ok, File.read!(args.path)}
+      end
+
+      guard(fn args, context ->
+        maybe_result =
+          context
+          |> Map.get(:cache, %{})
+          |> Map.get(args.path)
+
+        if maybe_result do
+          {:halt, {:ok, maybe_result}}
+        else
+          :cont
+        end
+      end)
+    end
+  end
+
+  test "when the guard halts the step isn't run and it's result is returned", %{tmp_dir: tmp_dir} do
+    test_file = Path.join(tmp_dir, "the_file.txt")
+    File.write!(test_file, "Great Scott!")
+
+    assert {:ok, "This is heavy"} =
+             Reactor.run(CachedReadReactor, %{path: test_file}, %{
+               cache: %{test_file => "This is heavy"}
+             })
+  end
+
+  test "when the guard continues, the step is run as normal", %{tmp_dir: tmp_dir} do
+    test_file = Path.join(tmp_dir, "the_file.txt")
+    File.write!(test_file, "Great Scott!")
+
+    assert {:ok, "Great Scott!"} = Reactor.run(CachedReadReactor, %{path: test_file})
+  end
+end

--- a/test/reactor/dsl/where_test.exs
+++ b/test/reactor/dsl/where_test.exs
@@ -1,0 +1,92 @@
+defmodule Reactor.Dsl.WhereTest do
+  use ExUnit.Case, async: true
+
+  defmodule ReplaceContentStep do
+    @moduledoc false
+    use Reactor.Step
+
+    def run(args, _context, _options) do
+      content = "Roads? Where we're going we don't need roads"
+      File.write!(args.path, content)
+      {:ok, content}
+    end
+
+    def undo(_value, _arguments, _context, _options) do
+      raise "hell"
+    end
+  end
+
+  defmodule PredicateReactor do
+    @moduledoc false
+    use Reactor
+
+    input :path
+
+    step :read, ReplaceContentStep do
+      argument :path, input(:path)
+      where(&File.exists?(&1.path))
+    end
+
+    return :read
+  end
+
+  defmodule FailingPredicateReactor do
+    @moduledoc false
+    use Reactor
+
+    input :path
+
+    step :read, ReplaceContentStep do
+      argument :path, input(:path)
+      where(&File.exists?(&1.path))
+    end
+
+    flunk :fail, "abort" do
+      wait_for :read
+    end
+
+    return :read
+  end
+
+  setup context do
+    test_sig =
+      context
+      |> Map.take(~w[line module file test]a)
+      |> :erlang.phash2()
+      |> Integer.to_string(16)
+
+    base = System.tmp_dir!()
+
+    tmp_dir = Path.join(base, test_sig)
+    File.mkdir_p!(tmp_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_dir)
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  test "when the predicate is true, it runs the step", %{tmp_dir: tmp_dir} do
+    test_file = Path.join(tmp_dir, "the_file.txt")
+    File.write!(test_file, "Great Scott!")
+
+    Reactor.run!(PredicateReactor, %{path: test_file})
+
+    assert File.read!(test_file) != "Great Scott!"
+  end
+
+  test "when the predicate is not true, it bypasses the step", %{tmp_dir: tmp_dir} do
+    test_file = Path.join(tmp_dir, "the_file.txt")
+    assert {:ok, nil} = Reactor.run(PredicateReactor, %{path: test_file})
+
+    refute File.exists?(test_file)
+  end
+
+  test "when a step is skipped it is not undone on failure", %{tmp_dir: tmp_dir} do
+    test_file = Path.join(tmp_dir, "the_file.txt")
+
+    assert {:error, error} = Reactor.run(FailingPredicateReactor, %{path: test_file})
+    assert Exception.message(error) =~ "abort"
+  end
+end


### PR DESCRIPTION
Allows steps to be skipped either by the use of a `where` predicate or a more comprehensive `guard` function.
