### PR TITLE
fix: Runtime step planning with intermediate results.

### DIFF
--- a/lib/reactor/dsl/switch.ex
+++ b/lib/reactor/dsl/switch.ex
@@ -133,7 +133,7 @@ defmodule Reactor.Dsl.Switch do
 
   defimpl Build do
     import Reactor.Utils
-    alias Reactor.{Argument, Builder, Planner}
+    alias Reactor.{Argument, Builder}
     alias Spark.{Dsl.Verifier, Error.DslError}
 
     def build(switch, reactor) do
@@ -189,8 +189,7 @@ defmodule Reactor.Dsl.Switch do
 
     defp build_match(match, switch, reactor) do
       with {:ok, reactor} <- build_steps(match.steps, reactor),
-           {:ok, reactor} <- maybe_build_return_step(match.return, switch, reactor),
-           {:ok, _} <- Planner.plan(reactor) do
+           {:ok, reactor} <- maybe_build_return_step(match.return, switch, reactor) do
         {:ok, {match.predicate, reactor.steps}}
       end
     end
@@ -199,8 +198,7 @@ defmodule Reactor.Dsl.Switch do
 
     defp build_default(switch, reactor) do
       with {:ok, reactor} <- build_steps(switch.default.steps, reactor),
-           {:ok, reactor} <- maybe_build_return_step(switch.default.return, switch, reactor),
-           {:ok, _} <- Planner.plan(reactor) do
+           {:ok, reactor} <- maybe_build_return_step(switch.default.return, switch, reactor) do
         {:ok, reactor.steps}
       end
     end

--- a/lib/reactor/planner.ex
+++ b/lib/reactor/planner.ex
@@ -24,7 +24,8 @@ defmodule Reactor.Planner do
     do: plan(%{reactor | plan: empty_graph()})
 
   def plan(reactor) do
-    with {:ok, graph} <- reduce_steps_into_graph(reactor.plan, reactor.steps),
+    with {:ok, graph} <-
+           reduce_steps_into_graph(reactor.plan, reactor.steps, reactor.intermediate_results),
          :ok <- assert_graph_not_cyclic(reactor, graph) do
       {:ok, %{reactor | steps: [], plan: graph}}
     end
@@ -46,7 +47,7 @@ defmodule Reactor.Planner do
 
   defp empty_graph, do: Graph.new(type: :directed, vertex_identifier: &__MODULE__.get_ref/1)
 
-  defp reduce_steps_into_graph(graph, steps) do
+  defp reduce_steps_into_graph(graph, steps, intermediate_results) do
     steps_by_name =
       graph
       |> Graph.vertices()
@@ -60,11 +61,11 @@ defmodule Reactor.Planner do
         if Graph.has_vertex?(graph, step) do
           graph
           |> Graph.replace_vertex(step, step)
-          |> reduce_arguments_into_graph(step, steps_by_name)
+          |> reduce_arguments_into_graph(step, steps_by_name, intermediate_results)
         else
           graph
           |> Graph.add_vertex(step, step.name)
-          |> reduce_arguments_into_graph(step, steps_by_name)
+          |> reduce_arguments_into_graph(step, steps_by_name, intermediate_results)
         end
 
       not_step, _ ->
@@ -77,8 +78,12 @@ defmodule Reactor.Planner do
     end)
   end
 
-  defp reduce_arguments_into_graph(graph, current_step, steps_by_name) do
+  defp reduce_arguments_into_graph(graph, current_step, steps_by_name, intermediate_results) do
     reduce_while_ok(current_step.arguments, graph, fn
+      argument, graph
+      when is_from_result(argument) and is_map_key(intermediate_results, argument.source.name) ->
+        {:ok, graph}
+
       argument, graph when is_from_result(argument) ->
         dependency_name = argument.source.name
 

--- a/test/reactor/dsl/verifier_test.exs
+++ b/test/reactor/dsl/verifier_test.exs
@@ -17,7 +17,7 @@ defmodule Reactor.Dsl.VerifierTest do
 
   test "reactors cannot have recursively duplicated step names" do
     assert_raise(DslError, ~r/duplicate steps/, fn ->
-      defmodule DuplicatedStepNameReactor do
+      defmodule RecursivelyDuplicatedStepNameReactor do
         @moduledoc false
         use Reactor
 


### PR DESCRIPTION
This fixes a bug where a Reactor would fail when steps are added at runtime which depend on an already computed result.  This is required to fix #136 which stops a Reactor from planning nested switch steps.
