### PR TITLE
improvement: Add the ability to render Mermaid flowcharts.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "backoff",
     "casted",
     "Desugars",
+    "indentify",
     "lvalue",
     "mappish",
     "noreply",

--- a/documentation/dsls/DSL-Reactor.md
+++ b/documentation/dsls/DSL-Reactor.md
@@ -1712,7 +1712,7 @@ is implemented.
 ### Examples
 ```
 map :double_numbers do
-  input input(:numbers)
+  source input(:numbers)
 
   step :double do
     argument :number, element(:double_numbers)
@@ -1733,7 +1733,7 @@ step :get_subscriptions do
 end
 
 map :cancel_subscriptions do
-  input result(:get_subscriptions)
+  source result(:get_subscriptions)
 
   step :cancel do
     argument :sub_id, element(:cancel_subscriptions, [:id])

--- a/documentation/dsls/DSL-Reactor.md
+++ b/documentation/dsls/DSL-Reactor.md
@@ -210,7 +210,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-around-argument-description){: #reactor-around-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-around-argument-description){: #reactor-around-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-around-argument-transform){: #reactor-around-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -470,7 +470,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-collect-argument-description){: #reactor-collect-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-collect-argument-description){: #reactor-collect-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-collect-argument-transform){: #reactor-collect-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -718,7 +718,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-compose-argument-description){: #reactor-compose-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-compose-argument-description){: #reactor-compose-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-compose-argument-transform){: #reactor-compose-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -907,6 +907,7 @@ end
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`level`](#reactor-debug-level){: #reactor-debug-level } | `:emergency \| :alert \| :critical \| :error \| :warning \| :notice \| :info \| :debug` | `:debug` | The log level to send the debug information to. |
+| [`description`](#reactor-debug-description){: #reactor-debug-description } | `String.t` |  | An optional description for the step. |
 
 
 ### reactor.debug.argument
@@ -970,7 +971,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-debug-argument-description){: #reactor-debug-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-debug-argument-description){: #reactor-debug-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-debug-argument-transform){: #reactor-debug-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -1224,7 +1225,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-flunk-argument-description){: #reactor-flunk-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-flunk-argument-description){: #reactor-flunk-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-flunk-argument-transform){: #reactor-flunk-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -1471,7 +1472,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-group-argument-description){: #reactor-group-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-group-argument-description){: #reactor-group-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-group-argument-transform){: #reactor-group-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -1827,7 +1828,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-map-argument-description){: #reactor-map-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-map-argument-description){: #reactor-map-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-map-argument-transform){: #reactor-map-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -2104,7 +2105,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-step-argument-description){: #reactor-step-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-step-argument-description){: #reactor-step-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-step-argument-transform){: #reactor-step-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 
@@ -2459,7 +2460,7 @@ argument :three, value(3)
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`description`](#reactor-template-argument-description){: #reactor-template-argument-description } | `String.t` |  | An optional description for the argument. |
+| [`description`](#reactor-template-argument-description){: #reactor-template-argument-description } | `String.t \| nil` |  | An optional description for the argument. |
 | [`transform`](#reactor-template-argument-transform){: #reactor-template-argument-transform } | `(any -> any) \| module \| nil` |  | An optional transformation function which can be used to modify the argument before it is passed to the step. |
 
 

--- a/lib/reactor.ex
+++ b/lib/reactor.ex
@@ -38,6 +38,7 @@ defmodule Reactor do
 
   defstruct context: %{},
             id: nil,
+            input_descriptions: %{},
             inputs: [],
             intermediate_results: %{},
             middleware: [],
@@ -119,6 +120,7 @@ defmodule Reactor do
   @type t :: %Reactor{
           context: context,
           id: any,
+          input_descriptions: %{atom => String.t()},
           inputs: [atom],
           intermediate_results: %{any => any},
           middleware: [Reactor.Middleware.t()],

--- a/lib/reactor/argument.ex
+++ b/lib/reactor/argument.ex
@@ -3,16 +3,46 @@ defmodule Reactor.Argument do
   A step argument.
   """
 
-  defstruct name: nil, source: nil, transform: nil
+  defstruct description: nil, name: nil, source: nil, transform: nil
 
   alias Reactor.{Argument, Template}
   import Reactor.Template, only: :macros
 
+  @options Spark.Options.new!(
+             transform: [
+               type:
+                 {:or,
+                  [
+                    nil,
+                    {:mfa_or_fun, 1},
+                    {:tuple, [:module, :non_empty_keyword_list]}
+                  ]},
+               required: false,
+               default: nil,
+               doc: """
+               An optional transformation function which can be used to modify the argument before it is passed to the step.
+               """
+             ],
+             description: [
+               type: {:or, [nil, :string]},
+               required: false,
+               default: nil,
+               doc: """
+               An optional description for the argument.
+               """
+             ]
+           )
+
+  @type transform :: nil | (any -> any) | {module, keyword} | mfa
+
   @type t :: %Argument{
+          description: nil | String.t(),
           name: atom,
           source: Template.t(),
-          transform: nil | (any -> any) | {module, keyword} | mfa
+          transform: transform
         }
+
+  @type options :: [{:description, nil | String.t()} | {:transform, transform}]
 
   defguardp is_spark_fun_behaviour(fun)
             when tuple_size(fun) == 2 and is_atom(elem(fun, 0)) and is_list(elem(fun, 1))
@@ -24,21 +54,34 @@ defmodule Reactor.Argument do
   defguardp is_transform(fun)
             when is_function(fun, 1) or is_spark_fun_behaviour(fun) or is_mfa(fun)
 
-  defguardp maybe_transform(fun) when is_nil(fun) or is_transform(fun)
+  defguardp maybe_options(options)
+            when is_nil(options) or is_list(options) or is_transform(options)
 
   @doc """
   Build an argument which refers to a reactor input with an optional
   transformation applied.
 
+  ## Options
+
+  #{Spark.Options.docs(@options)}
+
   ## Example
 
-      iex> Argument.from_input(:argument_name, :input_name, &String.to_integer/1)
+      iex> Argument.from_input(:argument_name, :input_name, transform: &String.to_integer/1)
 
   """
-  @spec from_input(atom, atom, nil | (any -> any)) :: Argument.t()
-  def from_input(name, input_name, transform \\ nil)
-      when is_atom(name) and maybe_transform(transform),
-      do: %Argument{name: name, source: %Template.Input{name: input_name}, transform: transform}
+  @spec from_input(atom, atom, nil | (any -> any) | options) :: Argument.t()
+  def from_input(name, input_name, options \\ nil)
+      when is_atom(name) and maybe_options(options) do
+    options = validate_options!(options)
+
+    %Argument{
+      description: options[:description],
+      name: name,
+      source: %Template.Input{name: input_name},
+      transform: options[:transform]
+    }
+  end
 
   @doc """
   Build an argument which refers to the result of another step with an optional
@@ -49,10 +92,18 @@ defmodule Reactor.Argument do
       iex> Argument.from_result(:argument_name, :step_name, &Atom.to_string/1)
 
   """
-  @spec from_result(atom, any, nil | (any -> any)) :: Argument.t()
-  def from_result(name, result_name, transform \\ nil)
-      when is_atom(name) and maybe_transform(transform),
-      do: %Argument{name: name, source: %Template.Result{name: result_name}, transform: transform}
+  @spec from_result(atom, any, nil | (any -> any) | options) :: Argument.t()
+  def from_result(name, result_name, options \\ nil)
+      when is_atom(name) and maybe_options(options) do
+    options = validate_options!(options)
+
+    %Argument{
+      description: options[:description],
+      name: name,
+      source: %Template.Result{name: result_name},
+      transform: options[:transform]
+    }
+  end
 
   @doc """
   Build an argument which refers to a statically defined value.
@@ -61,9 +112,17 @@ defmodule Reactor.Argument do
 
       iex> Argument.from_value(:argument_name, 10)
   """
-  @spec from_value(atom, any, nil | (any -> any)) :: Argument.t()
-  def from_value(name, value, transform \\ nil) when is_atom(name) and maybe_transform(transform),
-    do: %Argument{name: name, source: %Template.Value{value: value}, transform: transform}
+  @spec from_value(atom, any, nil | (any -> any) | options) :: Argument.t()
+  def from_value(name, value, options \\ nil) when is_atom(name) and maybe_options(options) do
+    options = validate_options!(options)
+
+    %Argument{
+      description: options[:description],
+      name: name,
+      source: %Template.Value{value: value},
+      transform: options[:transform]
+    }
+  end
 
   @doc """
   Build an argument which refers to to an element within a map step with an optional transformation applied.
@@ -73,14 +132,18 @@ defmodule Reactor.Argument do
       iex> Argument.from_element(:argument_name, &Atom.to_string/1)
 
   """
-  @spec from_element(any, any, nil | (any -> any)) :: Argument.t()
-  def from_element(name, element_name, transform \\ nil)
-      when maybe_transform(transform),
-      do: %Argument{
-        name: name,
-        source: %Template.Element{name: element_name},
-        transform: transform
-      }
+  @spec from_element(any, any, nil | (any -> any) | options) :: Argument.t()
+  def from_element(name, element_name, options \\ nil)
+      when maybe_options(options) do
+    options = validate_options!(options)
+
+    %Argument{
+      description: options[:description],
+      name: name,
+      source: %Template.Element{name: element_name},
+      transform: options[:transform]
+    }
+  end
 
   @doc """
   Build an argument directly from a template.
@@ -90,10 +153,18 @@ defmodule Reactor.Argument do
       iex> Argument.from_template(:argument_name, Reactor.Dsl.Argument.input(:input_name))
 
   """
-  @spec from_template(atom, Template.t(), nil | (any -> any)) :: Argument.t()
-  def from_template(name, template, transform \\ nil)
-      when is_atom(name) and is_template(template) and maybe_transform(transform),
-      do: %Argument{name: name, source: template, transform: transform}
+  @spec from_template(atom, Template.t(), nil | (any -> any) | options) :: Argument.t()
+  def from_template(name, template, options \\ nil)
+      when is_atom(name) and is_template(template) and maybe_options(options) do
+    options = validate_options!(options)
+
+    %Argument{
+      description: options[:description],
+      name: name,
+      source: template,
+      transform: options[:transform]
+    }
+  end
 
   @doc """
   Set a sub-path on the argument.
@@ -147,4 +218,10 @@ defmodule Reactor.Argument do
   """
   defguard has_sub_path(argument)
            when is_list(argument.source.sub_path) and argument.source.sub_path != []
+
+  defp validate_options!(options) when is_list(options),
+    do: Spark.Options.validate!(options, @options)
+
+  defp validate_options!(transform),
+    do: validate_options!(transform: transform)
 end

--- a/lib/reactor/builder.ex
+++ b/lib/reactor/builder.ex
@@ -30,7 +30,7 @@ defmodule Reactor.Builder do
   @type async? :: {:async?, boolean | (keyword -> boolean)}
 
   @typedoc "An optional step description"
-  @type description :: nil | String.t()
+  @type description :: {:description, nil | String.t()}
 
   @typedoc "How many times is the step allowed to retry?"
   @type max_retries :: {:max_retries, :infinity | non_neg_integer()}
@@ -38,7 +38,7 @@ defmodule Reactor.Builder do
   @typedoc "Optionally transform all the arguments into new arguments"
   @type arguments_transform ::
           {:transform,
-           nil | (%{optional(atom) => any} -> %{optional(atom) => any}) | {module | keyword} | mfa}
+           nil | (%{optional(atom) => any} -> %{optional(atom) => any}) | {module, keyword} | mfa}
 
   @type ref :: {:ref, :step_name | :make_ref}
   @type guards :: {:guards, [Reactor.Guard.Build.t()]}
@@ -65,23 +65,23 @@ defmodule Reactor.Builder do
   This both places the input in the Reactor for later input validation and adds
   steps to the Reactor which will emit and (possibly) transform the input.
   """
-  @spec add_input(Reactor.t(), any, nil | (any -> any)) :: {:ok, Reactor.t()} | {:error, any}
-  def add_input(reactor, name, transform \\ nil)
+  @spec add_input(Reactor.t(), any, Builder.Input.options()) :: {:ok, Reactor.t()} | {:error, any}
+  def add_input(reactor, name, options \\ nil)
 
-  def add_input(reactor, _name, _transform) when not is_reactor(reactor),
+  def add_input(reactor, _name, _options) when not is_reactor(reactor),
     do: {:error, argument_error(:reactor, "not a Reactor", reactor)}
 
-  def add_input(reactor, name, transform),
-    do: Builder.Input.add_input(reactor, name, transform)
+  def add_input(reactor, name, options),
+    do: Builder.Input.add_input(reactor, name, options)
 
   @doc """
   Raising version of `add_input/2..3`.
   """
-  @spec add_input!(Reactor.t(), any, nil | (any -> any)) :: Reactor.t() | no_return
-  def add_input!(reactor, name, transform \\ nil)
+  @spec add_input!(Reactor.t(), any, Builder.Input.options()) :: Reactor.t() | no_return
+  def add_input!(reactor, name, options \\ nil)
 
-  def add_input!(reactor, name, transform) do
-    case add_input(reactor, name, transform) do
+  def add_input!(reactor, name, options) do
+    case add_input(reactor, name, options) do
       {:ok, reactor} -> reactor
       {:error, reason} -> raise reason
     end

--- a/lib/reactor/builder/input.ex
+++ b/lib/reactor/builder/input.ex
@@ -6,33 +6,92 @@ defmodule Reactor.Builder.Input do
   `Reactor.Builder.add_input/3`.
   """
   alias Reactor.{Argument, Step}
-  import Reactor.Utils
+
+  @options Spark.Options.new!(
+             transform: [
+               type:
+                 {:or,
+                  [
+                    nil,
+                    {:mfa_or_fun, 1},
+                    {:tuple, [:module, :non_empty_keyword_list]}
+                  ]},
+               required: false,
+               default: nil,
+               doc: """
+               An optional transformation function which can be used to modify the input before it is used in the Reactor.
+               """
+             ],
+             description: [
+               type: {:or, [nil, :string]},
+               required: false,
+               default: nil,
+               doc: """
+               An optional description for the input.
+               """
+             ]
+           )
+
+  @type transform :: nil | (any -> any) | {Step.step(), keyword}
+  @type options :: [{:description, nil | String.t()}, {:transform, transform}] | transform
 
   @doc """
   Add a named input to the reactor.
   """
-  @spec add_input(Reactor.t(), any, nil | (any -> any) | {Step.step(), keyword}) ::
-          {:ok, Reactor.t()} | {:error, any}
-  def add_input(reactor, name, nil), do: {:ok, %{reactor | inputs: [name | reactor.inputs]}}
+  @spec add_input(Reactor.t(), any, options) :: {:ok, Reactor.t()} | {:error, any}
+  def add_input(reactor, name, options) do
+    case validate_options(options) do
+      {:ok, options} when is_nil(options.transform) ->
+        reactor =
+          reactor
+          |> do_add_input(name)
+          |> maybe_add_description(name, options.description)
 
-  def add_input(reactor, name, transform) when is_function(transform, 1),
-    do: add_input(reactor, name, {Step.Transform, fun: transform})
+        {:ok, reactor}
 
-  def add_input(reactor, name, transform)
-      when tuple_size(transform) == 2 and is_atom(elem(transform, 0)) and
-             is_list(elem(transform, 1)) do
+      {:ok, options} ->
+        reactor =
+          reactor
+          |> do_add_input(name)
+          |> add_input_transform(name, options.transform)
+          |> maybe_add_description(name, options.description)
+
+        {:ok, reactor}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp do_add_input(reactor, name), do: %{reactor | inputs: [name | reactor.inputs]}
+  defp maybe_add_description(reactor, _name, nil), do: reactor
+
+  defp maybe_add_description(reactor, name, description),
+    do: %{reactor | input_descriptions: Map.put(reactor.input_descriptions, name, description)}
+
+  defp add_input_transform(reactor, name, {module, options} = transform)
+       when is_atom(module) and is_list(options) do
     transform_step = %Step{
       arguments: [Argument.from_input(:value, name)],
       async?: true,
+      description: "Transformed result of the `#{inspect(name)}` step",
       impl: transform,
       name: {:__reactor__, :transform, :input, name},
       max_retries: 0,
       ref: make_ref()
     }
 
-    {:ok, %{reactor | inputs: [name | reactor.inputs], steps: [transform_step | reactor.steps]}}
+    %{reactor | steps: [transform_step | reactor.steps]}
   end
 
-  def add_input(_reactor, _name, transform),
-    do: {:error, argument_error(:transform, "Invalid transform function", transform)}
+  defp add_input_transform(reactor, name, transform),
+    do: add_input_transform(reactor, name, {Step.Transform, fun: transform})
+
+  defp validate_options(options) when is_list(options) do
+    with {:ok, options} <- Spark.Options.validate(options, @options) do
+      {:ok, Map.new(options)}
+    end
+  end
+
+  defp validate_options(transform), do: validate_options(transform: transform)
 end

--- a/lib/reactor/builder/step.ex
+++ b/lib/reactor/builder/step.ex
@@ -40,7 +40,7 @@ defmodule Reactor.Builder.Step do
       doc: "Context which will be merged with the reactor context when calling this step"
     ],
     description: [
-      type: :string,
+      type: {:or, [nil, :string]},
       required: false,
       doc: "An optional description for the step"
     ],

--- a/lib/reactor/dsl/argument.ex
+++ b/lib/reactor/dsl/argument.ex
@@ -190,7 +190,7 @@ defmodule Reactor.Dsl.Argument do
       imports: [Dsl.Argument],
       schema: [
         description: [
-          type: :string,
+          type: {:or, [:string, nil]},
           required: false,
           doc: """
           An optional description for the argument.
@@ -226,7 +226,7 @@ defmodule Reactor.Dsl.Argument do
       argument =
         argument
         |> Map.from_struct()
-        |> Map.take(~w[name source transform]a)
+        |> Map.take(~w[description name source transform]a)
         |> then(&struct(Argument, &1))
 
       {:ok, [argument]}

--- a/lib/reactor/dsl/around.ex
+++ b/lib/reactor/dsl/around.ex
@@ -91,6 +91,7 @@ defmodule Reactor.Dsl.Around do
            steps: sub_reactor.steps, fun: around.fun, allow_async?: around.allow_async?},
           around.arguments,
           async?: around.allow_async?,
+          description: around.description,
           guards: around.guards,
           max_retries: 0,
           ref: :step_name

--- a/lib/reactor/dsl/collect.ex
+++ b/lib/reactor/dsl/collect.ex
@@ -86,6 +86,7 @@ defmodule Reactor.Dsl.Collect do
         Step.ReturnAllArguments,
         step.arguments,
         async?: true,
+        description: step.description,
         guards: step.guards,
         max_retries: 1,
         transform: step.transform,

--- a/lib/reactor/dsl/compose.ex
+++ b/lib/reactor/dsl/compose.ex
@@ -81,6 +81,7 @@ defmodule Reactor.Dsl.Compose do
     def build(step, reactor) do
       Builder.compose(reactor, step.name, step.reactor, step.arguments,
         async?: step.async?,
+        description: step.description,
         guards: step.guards
       )
     end

--- a/lib/reactor/dsl/debug.ex
+++ b/lib/reactor/dsl/debug.ex
@@ -7,6 +7,7 @@ defmodule Reactor.Dsl.Debug do
 
   defstruct __identifier__: nil,
             arguments: [],
+            description: nil,
             guards: [],
             level: :debug,
             name: nil
@@ -16,6 +17,7 @@ defmodule Reactor.Dsl.Debug do
   @type t :: %Debug{
           __identifier__: any,
           arguments: [Argument.t()],
+          description: nil | String.t(),
           guards: [Where.t() | Guard.t()],
           level: Logger.level(),
           name: atom
@@ -58,6 +60,13 @@ defmodule Reactor.Dsl.Debug do
           doc: """
           The log level to send the debug information to.
           """
+        ],
+        description: [
+          type: :string,
+          required: false,
+          doc: """
+          An optional description for the step.
+          """
         ]
       ]
     }
@@ -71,6 +80,7 @@ defmodule Reactor.Dsl.Debug do
         debug.name,
         {Step.Debug, level: debug.level},
         debug.arguments,
+        description: debug.description,
         guards: debug.guards,
         max_retries: 0,
         ref: :step_name

--- a/lib/reactor/dsl/flunk.ex
+++ b/lib/reactor/dsl/flunk.ex
@@ -101,8 +101,9 @@ defmodule Reactor.Dsl.Flunk do
           |> maybe_append(message_argument(flunk))
 
         Builder.add_step(reactor, flunk.name, Step.Fail, arguments,
-          max_retries: 0,
+          description: flunk.description,
           guards: flunk.guards,
+          max_retries: 0,
           ref: :step_name
         )
       end

--- a/lib/reactor/dsl/group.ex
+++ b/lib/reactor/dsl/group.ex
@@ -103,6 +103,7 @@ defmodule Reactor.Dsl.Group do
            allow_async?: group.allow_async?},
           group.arguments,
           async?: group.allow_async?,
+          description: group.description,
           guards: group.guards,
           max_retries: 0,
           ref: :step_name

--- a/lib/reactor/dsl/guard.ex
+++ b/lib/reactor/dsl/guard.ex
@@ -64,7 +64,7 @@ defmodule Reactor.Dsl.Guard do
   defimpl Guard.Build do
     @doc false
     def build(guard) do
-      {:ok, [%Guard{fun: guard.fun}]}
+      {:ok, [%Guard{description: guard.description, fun: guard.fun}]}
     end
   end
 end

--- a/lib/reactor/dsl/input.ex
+++ b/lib/reactor/dsl/input.ex
@@ -73,7 +73,10 @@ defmodule Reactor.Dsl.Input do
 
   defimpl Dsl.Build do
     def build(input, reactor) do
-      Builder.add_input(reactor, input.name, input.transform)
+      Builder.add_input(reactor, input.name,
+        description: input.description,
+        transform: input.transform
+      )
     end
 
     def verify(_input, _dsl_state), do: :ok

--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -61,7 +61,7 @@ defmodule Reactor.Dsl.Map do
       examples: [
         """
         map :double_numbers do
-          input input(:numbers)
+          source input(:numbers)
 
           step :double do
             argument :number, element(:double_numbers)
@@ -80,7 +80,7 @@ defmodule Reactor.Dsl.Map do
         end
 
         map :cancel_subscriptions do
-          input result(:get_subscriptions)
+          source result(:get_subscriptions)
 
           step :cancel do
             argument :sub_id, element(:cancel_subscriptions, [:id])

--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -195,6 +195,7 @@ defmodule Reactor.Dsl.Map do
           map.name,
           {Step.Map, step_options},
           arguments,
+          description: map.description,
           guards: map.guards,
           max_retries: 0,
           ref: :step_name

--- a/lib/reactor/dsl/step.ex
+++ b/lib/reactor/dsl/step.ex
@@ -155,6 +155,7 @@ defmodule Reactor.Dsl.Step do
       with {:ok, step} <- rewrite_step(step, reactor.id) do
         Builder.add_step(reactor, step.name, step.impl, step.arguments,
           async?: step.async?,
+          description: step.description,
           guards: step.guards,
           max_retries: step.max_retries,
           transform: step.transform,

--- a/lib/reactor/dsl/switch.ex
+++ b/lib/reactor/dsl/switch.ex
@@ -148,6 +148,7 @@ defmodule Reactor.Dsl.Switch do
            on: :value, matches: matches, default: default, allow_async?: switch.allow_async?},
           [%Argument{name: :value, source: switch.on}],
           async?: switch.allow_async?,
+          description: switch.description,
           max_retries: 0,
           ref: :step_name
         )

--- a/lib/reactor/dsl/template.ex
+++ b/lib/reactor/dsl/template.ex
@@ -80,6 +80,7 @@ defmodule Reactor.Dsl.Template do
         {Step.Template, template: template.template},
         template.arguments,
         async?: true,
+        description: template.description,
         guards: template.guards,
         max_retries: 1,
         ref: :step_name

--- a/lib/reactor/guard.ex
+++ b/lib/reactor/guard.ex
@@ -12,9 +12,10 @@ defmodule Reactor.Guard do
   - `{:halt, result}` - the guard has failed - use `result` as the steps result.
   """
 
-  defstruct fun: nil
+  defstruct description: nil, fun: nil
 
   @type t :: %__MODULE__{
+          description: nil | String.t(),
           fun:
             (Reactor.inputs(), Reactor.context() -> :cont | {:halt, Reactor.Step.run_result()})
             | mfa

--- a/lib/reactor/mermaid.ex
+++ b/lib/reactor/mermaid.ex
@@ -1,0 +1,119 @@
+defmodule Reactor.Mermaid do
+  @moduledoc """
+  Converts Reactors and their related entities into a Mermaid diagram.
+
+  See [Mermaid](https://mermaid.js.org/) for more information.
+  """
+
+  @options Spark.Options.new!(
+             expand?: [
+               type: :boolean,
+               required: false,
+               default: false,
+               doc: "Whether or not to expand composed Reactors"
+             ],
+             describe?: [
+               type: :boolean,
+               required: false,
+               default: false,
+               doc: "Whether or not to include descriptions, if available"
+             ],
+             direction: [
+               type: {:in, [:top_to_bottom, :bottom_to_top, :right_to_left, :left_to_right]},
+               required: false,
+               default: :left_to_right,
+               doc: "The direction to render the flowchart"
+             ],
+             indent: [
+               type: :non_neg_integer,
+               required: false,
+               default: 0,
+               doc: "How much to indent the resulting mermaid"
+             ],
+             output: [
+               type: {:in, [:iodata, :binary]},
+               required: false,
+               default: :iodata,
+               doc: "Specify the output format. `iodata` is more performant"
+             ]
+           )
+
+  @type options :: Keyword.t()
+
+  @callback to_mermaid(module | struct, options) :: {:ok, __MODULE__.Node.t()} | {:error, any}
+
+  @doc """
+  Convert the Reactor into Mermaid.
+
+  ## Options
+
+  #{Spark.Options.docs(@options)}
+  """
+  @spec to_mermaid(module | Reactor.t(), options) :: {:ok, iodata()} | {:error, any}
+  def to_mermaid(reactor, options \\ []) do
+    with {:ok, options} <- Spark.Options.validate(options, @options) do
+      do_to_mermaid(reactor, options)
+    end
+  end
+
+  @doc """
+  Convert the Reactor into Mermaid
+
+  Raising version of `to_mermaid/2`
+  """
+  @spec to_mermaid!(module | Reactor.t(), options) :: iodata() | no_return()
+  def to_mermaid!(reactor, options \\ []) do
+    case to_mermaid(reactor, options) do
+      {:ok, iodata} -> iodata
+      {:error, reason} when is_exception(reason) -> raise reason
+      {:error, reason} -> raise RuntimeError, reason
+    end
+  end
+
+  defp do_to_mermaid(reactor, options) when is_atom(reactor) do
+    if Code.ensure_loaded?(reactor) && function_exported?(reactor, :spark_is, 0) &&
+         reactor.spark_is() == Reactor do
+      do_to_mermaid(reactor.reactor(), options)
+    else
+      {:error, ArgumentError.exception(message: "`reactor` argument is not a Reactor")}
+    end
+  end
+
+  defp do_to_mermaid(reactor, options) when is_struct(reactor, Reactor) do
+    with {:ok, reactor} <- Reactor.Planner.plan(reactor),
+         {:ok, sub_graph} <- __MODULE__.Reactor.to_mermaid(reactor, options),
+         {:ok, root} <- root_node(sub_graph, options) do
+      iodata = __MODULE__.Node.render(root, options[:indent] || 0)
+
+      if options[:output] == :binary do
+        string =
+          iodata
+          |> IO.iodata_to_binary()
+          |> String.trim_trailing(" ")
+
+        {:ok, string}
+      else
+        {:ok, iodata}
+      end
+    end
+  end
+
+  defp root_node(sub_graph, options) do
+    {:ok,
+     %__MODULE__.Node{
+       id: "root",
+       pre: [
+         "flowchart ",
+         __MODULE__.Utils.direction(options[:direction])
+       ],
+       children: [
+         "\n",
+         "start{\"Start\"}\n",
+         "start==>",
+         sub_graph.id,
+         "\n",
+         sub_graph
+       ]
+     }}
+  end
+end

--- a/lib/reactor/mermaid/argument.ex
+++ b/lib/reactor/mermaid/argument.ex
@@ -1,0 +1,69 @@
+defmodule Reactor.Mermaid.Argument do
+  @moduledoc false
+  import Reactor.Mermaid.Utils
+  alias Reactor.{Argument, Mermaid.Node}
+  require Argument
+  @behaviour Reactor.Mermaid
+
+  @doc false
+  def to_mermaid(argument, options) when Argument.is_from_value(argument) do
+    target_id =
+      options
+      |> Keyword.fetch!(:target_id)
+
+    source_id =
+      argument.source.value
+      |> mermaid_id(:value)
+
+    {:ok,
+     %Node{
+       pre: [
+         source_id,
+         "{{\"`",
+         md_escape(inspect(argument.source.value, pretty: true)),
+         "`\"}}\n",
+         do_argument_link(source_id, target_id, argument, options)
+       ]
+     }}
+  end
+
+  def to_mermaid(argument, options) when Argument.is_from_input(argument) do
+    target_id =
+      options
+      |> Keyword.fetch!(:target_id)
+
+    source_id =
+      {options[:reactor_id], argument.source.name}
+      |> mermaid_id(:input)
+
+    content =
+      source_id
+      |> do_argument_link(target_id, argument, options)
+
+    {:ok, %Node{pre: content}}
+  end
+
+  def to_mermaid(argument, options) do
+    target_id =
+      options
+      |> Keyword.fetch!(:target_id)
+
+    source_id =
+      {options[:reactor_id], argument.source.name}
+      |> mermaid_id(:step)
+
+    content =
+      source_id
+      |> do_argument_link(target_id, argument, options)
+
+    {:ok, %Node{pre: content}}
+  end
+
+  defp do_argument_link(source_id, target_id, argument, options) do
+    if options[:describe?] && is_binary(argument.description) do
+      "#{source_id} -->|#{name(argument.name)} -- #{argument.description}|#{target_id}\n"
+    else
+      "#{source_id} -->|#{name(argument.name)}|#{target_id}\n"
+    end
+  end
+end

--- a/lib/reactor/mermaid/node.ex
+++ b/lib/reactor/mermaid/node.ex
@@ -1,0 +1,77 @@
+defmodule Reactor.Mermaid.Node do
+  @moduledoc """
+  A node in the mermaid graph
+  """
+  defstruct children: [], id: nil, post: [], pre: []
+
+  @type node_data :: node_list | binary | byte | t
+  @type node_list :: [node_data] | node_data
+
+  @type t :: %__MODULE__{
+          children: node_list,
+          id: nil | String.t(),
+          post: node_list,
+          pre: node_list
+        }
+
+  @indent "    "
+
+  @doc """
+  Render the node at the provided indent level.
+  """
+  @spec render(t, non_neg_integer()) :: iodata
+  def render(node, indent) do
+    indent =
+      [@indent]
+      |> Stream.cycle()
+      |> Enum.take(indent)
+
+    do_render([node], [], indent)
+  end
+
+  defguardp is_byte(byte) when is_integer(byte) and byte >= 0 and byte <= 255
+
+  defp do_render([], result, _indent), do: result
+  defp do_render([[] | tail], result, indent), do: do_render(tail, result, indent)
+
+  defp do_render([head | tail], result, indent) when is_list(head) do
+    head = do_render(head, [], indent)
+    do_render(tail, [result, head], indent)
+  end
+
+  defp do_render([head | tail], result, indent) when is_struct(head, __MODULE__) do
+    pre = do_render(head.pre, [], indent)
+    children = do_render(head.children, [], [indent, @indent])
+    post = do_render(head.post, [], indent)
+    do_render(tail, [result, pre, children, post], indent)
+  end
+
+  defp do_render([head | tail], result, indent) when is_binary(head),
+    do: do_render(tail, [result, indent(head, indent)], indent)
+
+  defp do_render([head | tail], result, indent)
+       when is_integer(head) and head >= 0 and head <= 255,
+       do: do_render(tail, [result, indent(head, indent)], indent)
+
+  defp do_render(bin, result, indent) when is_binary(bin),
+    do: do_render([], [result, indent(bin, indent)], indent)
+
+  defp do_render(int, result, indent) when is_byte(int),
+    do: do_render([], [result, indent(int, indent)], indent)
+
+  defp indent("", _indent), do: ""
+
+  defp indent(input, []), do: input
+
+  defp indent(bin, indent) when is_binary(bin) do
+    bin
+    |> String.split("\n")
+    |> Enum.intersperse(["\n", indent])
+  end
+
+  defp indent(?\n, indent) do
+    [?\n, indent]
+  end
+
+  defp indent(int, _indent) when is_byte(int), do: IO.chardata_to_string([int])
+end

--- a/lib/reactor/mermaid/reactor.ex
+++ b/lib/reactor/mermaid/reactor.ex
@@ -1,0 +1,85 @@
+defmodule Reactor.Mermaid.Reactor do
+  @moduledoc false
+  alias Reactor.Mermaid.{Node, Step}
+  import Reactor.Utils
+  import Reactor.Mermaid.Utils
+  @behaviour Reactor.Mermaid
+
+  @doc false
+  @impl true
+  def to_mermaid(reactor, options) when is_struct(reactor, Reactor) do
+    id = mermaid_id(reactor.id, :reactor)
+
+    with {:ok, reactor} <- Reactor.Planner.plan(reactor),
+         {:ok, inputs} <- generate_inputs(reactor, options),
+         {:ok, steps} <- generate_steps(reactor, options) do
+      return_step_id = mermaid_id({reactor.id, reactor.return}, :step)
+      return_id = mermaid_id(reactor.id, :return)
+
+      {:ok,
+       %Node{
+         id: id,
+         pre: [
+           "subgraph ",
+           id,
+           "[\"",
+           name(reactor.id),
+           "\"]"
+         ],
+         children: [
+           "\n",
+           "direction ",
+           direction(options[:direction]),
+           "\n",
+           inputs,
+           steps,
+           return_id,
+           "{\"Return\"}\n",
+           return_step_id,
+           "==>",
+           return_id
+         ],
+         post: [
+           "\n",
+           "end\n"
+         ]
+       }}
+    end
+  end
+
+  defp generate_inputs(reactor, options) do
+    reactor.inputs
+    |> map_while_ok(&generate_input(&1, reactor, options))
+  end
+
+  defp generate_input(input_name, reactor, options) do
+    id = mermaid_id({reactor.id, input_name}, :input)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          ">\"`",
+          "**Input ",
+          to_string(input_name),
+          "**",
+          "\n",
+          md_escape(Map.get(reactor.input_descriptions, input_name)),
+          "`\"]",
+          "\n"
+        ]
+      else
+        [id, ">\"Input ", to_string(input_name), "\"]\n"]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+
+  defp generate_steps(reactor, options) do
+    options = Keyword.put(options, :reactor_id, reactor.id)
+
+    reactor.plan
+    |> Graph.vertices()
+    |> map_while_ok(&Step.to_mermaid(&1, options))
+  end
+end

--- a/lib/reactor/mermaid/step.ex
+++ b/lib/reactor/mermaid/step.ex
@@ -1,0 +1,65 @@
+defmodule Reactor.Mermaid.Step do
+  @moduledoc false
+  import Reactor.Utils
+  import Reactor.Mermaid.Utils
+  alias Reactor.Mermaid.{Argument, Node}
+  @behaviour Reactor.Mermaid
+
+  @doc false
+  @impl true
+  def to_mermaid(step, options) do
+    with {:ok, step_node} <- render_step(step, options),
+         {:ok, arguments} <-
+           generate_arguments(step.arguments, Keyword.put(options, :target_id, step_node.id)) do
+      {:ok, %{step_node | pre: [arguments, step_node.pre]}}
+    end
+  end
+
+  defp generate_arguments(arguments, options) do
+    arguments
+    |> map_while_ok(&Argument.to_mermaid(&1, options))
+  end
+
+  defp render_step(step, options) do
+    module = impl_for(step)
+
+    if Spark.implements_behaviour?(module, Reactor.Mermaid) do
+      module.to_mermaid(step, options)
+    else
+      default_describe_step(step, module, options)
+    end
+  end
+
+  @doc false
+  def default_describe_step(step, module, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          md_escape(name(step.name)),
+          " \\(",
+          inspect(module),
+          "\\)**\n",
+          md_escape(step.description),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+
+  defp impl_for(%{impl: {module, _}}) when is_atom(module), do: module
+  defp impl_for(%{impl: module}) when is_atom(module), do: module
+end

--- a/lib/reactor/mermaid/utils.ex
+++ b/lib/reactor/mermaid/utils.ex
@@ -1,0 +1,90 @@
+defmodule Reactor.Mermaid.Utils do
+  @moduledoc """
+  Utilities for generating Mermaid.
+  """
+
+  @safe_id ~r/\A[a-zA-Z0-9\._-]+\Z/
+
+  @doc "Escape markdown as needed"
+  def md_escape(nil), do: ""
+
+  def md_escape(md) do
+    md
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("`", "&#96;")
+    |> String.replace("*", "\\*")
+    |> String.replace("_", "\\_")
+    |> String.replace("{", "\\{")
+    |> String.replace("}", "\\}")
+    |> String.replace("[", "\\[")
+    |> String.replace("]", "\\]")
+    |> String.replace("<", "\\<")
+    |> String.replace(">", "\\>")
+    |> String.replace("(", "\\(")
+    |> String.replace(")", "\\)")
+    |> String.replace("#", "\\#")
+    |> String.replace("+", "\\+")
+    |> String.replace("-", "\\-")
+    |> String.replace(".", "\\.")
+    |> String.replace("!", "\\!")
+    |> String.replace("|", "\\|")
+  end
+
+  @doc "Generate a mermaid ID for a term"
+  @spec mermaid_id(any, String.Chars.t()) :: String.t()
+  def mermaid_id(name, prefix) when is_atom(name) do
+    name =
+      name
+      |> to_string()
+      |> deelixirify()
+
+    if Regex.match?(@safe_id, name) do
+      "#{prefix}_#{name}"
+    else
+      "#{prefix}_#{:erlang.phash2(name)}"
+    end
+  end
+
+  def mermaid_id(name, prefix) when is_binary(name) do
+    if Regex.match?(@safe_id, name) do
+      "#{prefix}_#{name}"
+    else
+      "#{prefix}_#{:erlang.phash2(name)}"
+    end
+  end
+
+  def mermaid_id(name, prefix), do: "#{prefix}_#{:erlang.phash2(name)}"
+
+  @doc "Generate a name which can be used within a Mermaid node"
+  def name(name) when is_binary(name) do
+    if String.printable?(name) do
+      name
+    else
+      inspect(name)
+    end
+  end
+
+  def name(name) when is_atom(name) do
+    name
+    |> to_string()
+    |> deelixirify()
+  end
+
+  def name(name), do: inspect(name)
+
+  defp deelixirify(name) do
+    if String.starts_with?(name, "Elixir.") do
+      String.replace_leading(name, "Elixir.", "")
+    else
+      name
+    end
+  end
+
+  @doc "Convert the direction atom into a mermaid direction"
+  @spec direction(atom) :: String.t()
+  def direction(:top_to_bottom), do: "TD"
+  def direction(:bottom_to_top), do: "BT"
+  def direction(:left_to_right), do: "LR"
+  def direction(:right_to_left), do: "RL"
+end

--- a/lib/reactor/step/anon_fn.ex
+++ b/lib/reactor/step/anon_fn.ex
@@ -13,6 +13,7 @@ defmodule Reactor.Step.AnonFn do
   """
 
   use Reactor.Step
+  @behaviour Reactor.Mermaid
 
   @doc false
   @impl true
@@ -82,4 +83,9 @@ defmodule Reactor.Step.AnonFn do
   def can?(%{impl: {_, opts}}, :undo), do: is_function(Keyword.get(opts, :undo))
   def can?(%{impl: {_, opts}}, :compensate), do: is_function(Keyword.get(opts, :compensate))
   def can?(_, _), do: false
+
+  @doc false
+  @impl true
+  def to_mermaid(step, options),
+    do: __MODULE__.Mermaid.to_mermaid(step, options)
 end

--- a/lib/reactor/step/anon_fn/mermaid.ex
+++ b/lib/reactor/step/anon_fn/mermaid.ex
@@ -1,0 +1,46 @@
+defmodule Reactor.Step.AnonFn.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `AnonFn` steps.
+  """
+
+  alias Reactor.Mermaid.{Node, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(%{impl: {module, opts}} = step, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        functions =
+          opts
+          |> Keyword.take([:run, :compensate, :undo])
+          |> Enum.sort_by(&elem(&1, 0))
+          |> Enum.reject(&is_nil(elem(&1, 1)))
+          |> Enum.map(fn {name, fun} ->
+            [
+              "- #{name}: _",
+              md_escape(inspect(fun)),
+              "_"
+            ]
+          end)
+          |> Enum.intersperse(["\n"])
+
+        [
+          id,
+          "[\"`**",
+          name(step.name),
+          " \\(",
+          inspect(module),
+          "\\)**\n",
+          functions,
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [id, "[\"", name(step.name), "(", inspect(module), ")\"]\n"]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+end

--- a/lib/reactor/step/around/mermaid.ex
+++ b/lib/reactor/step/around/mermaid.ex
@@ -1,0 +1,58 @@
+defmodule Reactor.Step.Around.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `around` steps.
+  """
+
+  alias Reactor.Mermaid.{Node, Reactor, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(step, reactor, options) do
+    with {:ok, sub_graph} <- Reactor.to_mermaid(reactor, options),
+         {:ok, node} <- describe_step(step, options) do
+      inner_return_id = mermaid_id(reactor.id, :return)
+
+      links =
+        reactor.inputs
+        |> Enum.map(fn input ->
+          [node.id, "-->", mermaid_id({reactor.id, input}, :input), "\n"]
+        end)
+        |> Enum.concat([inner_return_id, "-->", node.id, "\n"])
+
+      {:ok, %{node | post: [sub_graph, node.post, links]}}
+    end
+  end
+
+  defp describe_step(%{impl: {module, opts}} = step, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+    fun = Keyword.fetch!(opts, :fun)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          md_escape(name(step.name)),
+          " \\(",
+          inspect(module),
+          "\\)**\n",
+          "_",
+          md_escape(inspect(fun)),
+          "_",
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+end

--- a/lib/reactor/step/compose.ex
+++ b/lib/reactor/step/compose.ex
@@ -8,6 +8,7 @@ defmodule Reactor.Step.Compose do
   """
 
   use Reactor.Step
+  @behaviour Reactor.Mermaid
 
   @doc false
   @impl true
@@ -19,4 +20,9 @@ defmodule Reactor.Step.Compose do
       async?: options[:async?] || false
     )
   end
+
+  @doc false
+  @impl true
+  def to_mermaid(step, options),
+    do: __MODULE__.Mermaid.to_mermaid(step, options)
 end

--- a/lib/reactor/step/compose/mermaid.ex
+++ b/lib/reactor/step/compose/mermaid.ex
@@ -1,0 +1,62 @@
+defmodule Reactor.Step.Compose.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `compose` steps.
+  """
+
+  alias Reactor.Mermaid.{Node, Reactor, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(%{impl: {module, opts}} = step, options) do
+    reactor =
+      case Keyword.fetch!(opts, :reactor) do
+        reactor when is_struct(reactor) -> reactor
+        reactor when is_atom(reactor) -> reactor.reactor()
+      end
+
+    reactor = %{reactor | id: {reactor.id, step.name}}
+
+    with {:ok, sub_graph} <- Reactor.to_mermaid(reactor, options),
+         {:ok, node} <- describe_step(step, module, options) do
+      inner_return_id = mermaid_id(reactor.id, :return)
+
+      links =
+        reactor.inputs
+        |> Enum.map(fn input ->
+          [node.id, "-->", mermaid_id({reactor.id, input}, :input), "\n"]
+        end)
+        |> Enum.concat([inner_return_id, "-->", node.id, "\n"])
+
+      {:ok, %{node | post: [sub_graph, node.post, links]}}
+    end
+  end
+
+  defp describe_step(step, module, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          md_escape(name(step.name)),
+          " \\(",
+          inspect(module),
+          "\\)**",
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+end

--- a/lib/reactor/step/group/mermaid.ex
+++ b/lib/reactor/step/group/mermaid.ex
@@ -1,0 +1,69 @@
+defmodule Reactor.Step.Group.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `group` steps.
+  """
+
+  alias Reactor.Mermaid.{Node, Reactor, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(step, reactor, options) do
+    with {:ok, sub_graph} <- Reactor.to_mermaid(reactor, options),
+         {:ok, node} <- describe_step(step, options) do
+      inner_return_id = mermaid_id(reactor.id, :return)
+
+      links =
+        reactor.inputs
+        |> Enum.map(fn input ->
+          [node.id, "-->", mermaid_id({reactor.id, input}, :input), "\n"]
+        end)
+        |> Enum.concat([inner_return_id, "-->", node.id, "\n"])
+
+      {:ok, %{node | post: [sub_graph, node.post, links]}}
+    end
+  end
+
+  defp describe_step(%{impl: {module, opts}} = step, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        functions =
+          opts
+          |> Keyword.take([:before, :after])
+          |> Enum.sort_by(&elem(&1, 0))
+          |> Enum.reject(&is_nil(elem(&1, 1)))
+          |> Enum.map(fn {name, fun} ->
+            [
+              "- #{name}: _",
+              md_escape(inspect(fun)),
+              "_"
+            ]
+          end)
+          |> Enum.intersperse(["\n"])
+
+        [
+          id,
+          "[\"`**",
+          md_escape(name(step.name)),
+          " \\(",
+          inspect(module),
+          "\\)**\n",
+          functions,
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+end

--- a/lib/reactor/step/map.ex
+++ b/lib/reactor/step/map.ex
@@ -7,6 +7,8 @@ defmodule Reactor.Step.Map do
   alias Spark.Options
   import Reactor.Utils
 
+  @behaviour Reactor.Mermaid
+
   @option_schema [
     state: [
       type: {:in, [:init, :iterating]},
@@ -94,6 +96,10 @@ defmodule Reactor.Step.Map do
       end
     end
   end
+
+  @doc false
+  @impl true
+  def to_mermaid(step, options), do: __MODULE__.Mermaid.to_mermaid(step, options)
 
   defp do_init(source, arguments, options, map_step) when Iter.is_iter(source) do
     source =

--- a/lib/reactor/step/map/mermaid.ex
+++ b/lib/reactor/step/map/mermaid.ex
@@ -1,0 +1,95 @@
+defmodule Reactor.Step.Map.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `map` steps.
+  """
+
+  alias Reactor.{Argument, Builder, Mermaid, Template}
+  import Reactor.Utils
+  import Mermaid.Utils
+  require Argument
+
+  @doc false
+  def to_mermaid(%{impl: {Reactor.Step.Map, opts}} = step, options) do
+    steps = Keyword.get(opts, :steps, [])
+
+    with {:ok, reactor} <- build_nested_reactor(step.arguments, step.name, steps, opts[:return]),
+         {:ok, sub_graph} <- Mermaid.Reactor.to_mermaid(reactor, options),
+         {:ok, node} <- describe_step(step, options) do
+      inner_return_id = mermaid_id(reactor.id, :return)
+
+      links =
+        reactor.inputs
+        |> Enum.map(fn input ->
+          [node.id, "-->", mermaid_id({reactor.id, input}, :input), "\n"]
+        end)
+        |> Enum.concat([inner_return_id, "-->", node.id, "\n"])
+
+      {:ok, %{node | post: [sub_graph, node.post, links]}}
+    end
+  end
+
+  defp build_nested_reactor(arguments, name, steps, return) do
+    reactor = Builder.new({__MODULE__, name})
+
+    with {:ok, reactor} <- build_inputs(reactor, arguments),
+         {:ok, reactor} <- build_steps(reactor, steps) do
+      {:ok, %{reactor | return: return}}
+    end
+  end
+
+  defp build_inputs(reactor, arguments) do
+    arguments
+    |> map_while_ok(&Argument.Build.build/1)
+    |> and_then(&{:ok, List.flatten(&1)})
+    |> and_then(fn arguments ->
+      reduce_while_ok(arguments, reactor, &Builder.add_input(&2, &1.name))
+    end)
+  end
+
+  defp build_steps(reactor, steps) do
+    steps =
+      Enum.map(steps, fn step ->
+        arguments =
+          Enum.map(step.arguments, fn
+            argument when Argument.is_from_element(argument) ->
+              %{argument | source: %Template.Input{name: :source}}
+
+            argument ->
+              argument
+          end)
+
+        %{step | arguments: arguments}
+      end)
+
+    {:ok, %{reactor | steps: Enum.concat(steps, reactor.steps)}}
+  end
+
+  defp describe_step(%{impl: {module, _opts}} = step, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          md_escape(name(step.name)),
+          " \\(",
+          inspect(module),
+          "\\)**",
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Mermaid.Node{id: id, pre: content}}
+  end
+end

--- a/lib/reactor/step/switch.ex
+++ b/lib/reactor/step/switch.ex
@@ -43,6 +43,7 @@ defmodule Reactor.Step.Switch do
   use Reactor.Step
   alias Reactor.Step
   import Reactor.Utils
+  @behaviour Reactor.Mermaid
 
   @typedoc """
   A list of predicates and steps to execute if the predicate returns a truthy
@@ -78,6 +79,11 @@ defmodule Reactor.Step.Switch do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  @doc false
+  @impl true
+  def to_mermaid(step, options),
+    do: __MODULE__.Mermaid.to_mermaid(step, options)
 
   defp find_match(matches, value) do
     Enum.reduce_while(matches, :no_match, fn {predicate, steps}, :no_match ->

--- a/lib/reactor/step/switch/mermaid.ex
+++ b/lib/reactor/step/switch/mermaid.ex
@@ -1,0 +1,150 @@
+defmodule Reactor.Step.Switch.Mermaid do
+  @moduledoc """
+  Mermaid rendering for `switch` steps.
+  """
+
+  import Reactor.Utils
+  alias Reactor.Mermaid.{Node, Step, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(%{impl: {_module, opts}} = step, options) do
+    branches =
+      opts
+      |> Keyword.get(:matches, [])
+      |> Enum.concat([{:default, opts[:default]}])
+      |> Enum.reject(fn {_, steps} -> is_nil(steps) || steps == [] end)
+
+    with {:ok, node} <- describe_step(step, options),
+         {:ok, branches} <- describe_branches(step, branches, options) do
+      decision_id = "#{node.id}_decision"
+
+      decision = [
+        decision_id,
+        "@{shape: diamond, label: \"Decision for ",
+        name(step.name),
+        "\"}\n",
+        node.id,
+        "-->",
+        decision_id,
+        "\n"
+      ]
+
+      links =
+        Enum.map(branches, fn branch ->
+          [decision_id, "-->", branch.id, "\n"]
+        end)
+
+      {:ok, %{node | post: [node.post, decision, links, branches]}}
+    end
+  end
+
+  defp describe_step(%{impl: {module, _opts}} = step, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          name(step.name),
+          " \\(",
+          inspect(module),
+          "\\)**",
+          if(step.description, do: ["\n", md_escape(step.description)], else: []),
+          "`\"]\n"
+        ]
+      else
+        [
+          id,
+          "[\"",
+          name(step.name),
+          "(",
+          inspect(module),
+          ")\"]\n"
+        ]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+
+  defp describe_branches(step, branches, options) do
+    map_while_ok(branches, &describe_branch(step, &1, options))
+  end
+
+  defp describe_branch(step, {:default, steps}, options) do
+    id = mermaid_id({options[:reactor_id], step.name, :default}, :step)
+
+    with {:ok, steps} <- generate_steps(steps, options) do
+      {:ok,
+       %Node{
+         id: id,
+         pre: [
+           "subgraph ",
+           id,
+           "[\"default branch of ",
+           name(step.name),
+           "\"]"
+         ],
+         children: [
+           "\n",
+           steps,
+           "direction ",
+           direction(options[:direction])
+         ],
+         post: [
+           "\n",
+           "end\n"
+         ]
+       }}
+    end
+  end
+
+  defp describe_branch(step, {predicate, steps}, options) do
+    id = mermaid_id({options[:reactor_id], step.name, predicate}, :step)
+
+    with {:ok, steps} <- generate_steps(steps, options) do
+      content =
+        if options[:describe?] do
+          [
+            "subgraph ",
+            id,
+            "[\"`match branch of ",
+            name(step.name),
+            "\n_",
+            md_escape(inspect(predicate)),
+            "_",
+            "`\"]"
+          ]
+        else
+          [
+            "subgraph ",
+            id,
+            "[\"match branch of ",
+            name(step.name),
+            "\"]"
+          ]
+        end
+
+      {:ok,
+       %Node{
+         id: id,
+         pre: content,
+         children: [
+           "\n",
+           steps,
+           "direction ",
+           direction(options[:direction])
+         ],
+         post: [
+           "\n",
+           "end\n"
+         ]
+       }}
+    end
+  end
+
+  defp generate_steps(steps, options) do
+    map_while_ok(steps, &Step.to_mermaid(&1, options))
+  end
+end

--- a/lib/reactor/step/transform.ex
+++ b/lib/reactor/step/transform.ex
@@ -20,6 +20,7 @@ defmodule Reactor.Step.Transform do
 
   alias Reactor.{Error.Invalid.MissingArgumentError, Error.Invalid.TransformError, Step}
   use Step
+  @behaviour Reactor.Mermaid
 
   @doc false
   @impl true
@@ -37,6 +38,12 @@ defmodule Reactor.Step.Transform do
            arguments: arguments
          )}
     end
+  end
+
+  @doc false
+  @impl true
+  def to_mermaid(%{impl: {__MODULE__, opts}} = step, options) do
+    __MODULE__.Mermaid.to_mermaid(step, opts[:fun], options)
   end
 
   defp do_transform(value, opts) do

--- a/lib/reactor/step/transform/mermaid.ex
+++ b/lib/reactor/step/transform/mermaid.ex
@@ -1,0 +1,41 @@
+defmodule Reactor.Step.Transform.Mermaid do
+  @moduledoc """
+  Mermaid rendering for transform steps.
+  """
+
+  alias Reactor.Mermaid.{Node, Utils}
+  import Utils
+
+  @doc false
+  def to_mermaid(step, fun, options) do
+    id = mermaid_id({options[:reactor_id], step.name}, :step)
+
+    name =
+      case step.name do
+        {:__reactor__, :transform, :input, input} ->
+          "Transform input #{name(input)}"
+
+        {:__reactor__, :transform, argument_name, _step_name} ->
+          "Transform argument #{name(argument_name)}"
+
+        other ->
+          name(other)
+      end
+
+    content =
+      if options[:describe?] do
+        [
+          id,
+          "[\"`**",
+          name,
+          "**\n_",
+          md_escape(inspect(fun)),
+          "_`\"]\n"
+        ]
+      else
+        [id, "[", name, "]\n"]
+      end
+
+    {:ok, %Node{id: id, pre: content}}
+  end
+end

--- a/test/reactor/builder/input_test.exs
+++ b/test/reactor/builder/input_test.exs
@@ -28,21 +28,21 @@ defmodule Reactor.Builder.InputTest do
     test "when the input has a transform impl the input and a transform step are added to the reactor" do
       assert {:ok, reactor} =
                Builder.new()
-               |> Input.add_input(:marty, {Step.Transform, run: &Function.identity/1})
+               |> Input.add_input(:marty, {Step.Transform, fun: &Function.identity/1})
 
       assert :marty in reactor.inputs
       assert [step] = reactor.steps
 
       assert step.name == {:__reactor__, :transform, :input, :marty}
-      assert step.impl == {Step.Transform, run: &Function.identity/1}
+      assert step.impl == {Step.Transform, fun: &Function.identity/1}
     end
 
     test "when the transform is not valid, it returns an error" do
-      assert {:error, %ArgumentError{} = error} =
+      assert {:error, %Spark.Options.ValidationError{} = error} =
                Builder.new()
                |> Input.add_input(:marty, :doc)
 
-      assert Exception.message(error) =~ ~r/invalid transform function/i
+      assert Exception.message(error) =~ ~r/expected :transform option/i
     end
   end
 end

--- a/test/reactor/dsl/argument_test.exs
+++ b/test/reactor/dsl/argument_test.exs
@@ -31,12 +31,14 @@ defmodule Reactor.Dsl.ArgumentTest do
       assert {:ok,
               [
                 %Argument{
+                  description: "Example",
                   name: :name,
                   source: %Template.Input{name: :source},
                   transform: ^transform
                 }
               ]} =
                Argument.Build.build(%Dsl.Argument{
+                 description: "Example",
                  name: :name,
                  source: %Template.Input{name: :source},
                  transform: transform,

--- a/test/reactor/dsl/input_test.exs
+++ b/test/reactor/dsl/input_test.exs
@@ -1,0 +1,58 @@
+defmodule Reactor.Dsl.InputTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  test "reactors can have inputs" do
+    defmodule InputReactor do
+      @moduledoc false
+      use Reactor
+
+      input :input
+
+      collect :result do
+        argument :input, input(:input)
+      end
+
+      return :result
+    end
+
+    assert {:ok, %{input: "Marty McFly"}} = Reactor.run(InputReactor, %{input: "Marty McFly"})
+  end
+
+  test "reactor inputs can be transformed" do
+    defmodule InputTransformReactor do
+      @moduledoc false
+      use Reactor
+
+      input :input, transform: &String.upcase/1
+
+      collect :result do
+        argument :input, input(:input)
+      end
+
+      return :result
+    end
+
+    assert {:ok, %{input: "MARTY MCFLY"}} =
+             Reactor.run(InputTransformReactor, %{input: "Marty McFly"})
+  end
+
+  test "reactor inputs can have descriptions" do
+    defmodule InputDescriptionReactor do
+      @moduledoc false
+      use Reactor
+
+      input :input, description: "An example input"
+
+      collect :result do
+        argument :input, input(:input)
+      end
+
+      return :result
+    end
+
+    reactor = Reactor.Info.to_struct!(InputDescriptionReactor)
+
+    assert %{input: "An example input"} = reactor.input_descriptions
+  end
+end

--- a/test/reactor/mermaid_test.exs
+++ b/test/reactor/mermaid_test.exs
@@ -1,0 +1,680 @@
+defmodule Reactor.MermaidTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  test "basic reactor" do
+    defmodule BasicReactor do
+      @moduledoc false
+      use Reactor
+      input :whom
+
+      step :greet, Example.Step.Greeter do
+        argument :whom, input(:whom)
+      end
+
+      return :greet
+    end
+
+    expected = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.BasicReactor
+        subgraph reactor_Reactor.MermaidTest.BasicReactor["Reactor.MermaidTest.BasicReactor"]
+            direction LR
+            input_105483575>"Input whom"]
+            input_105483575 -->|whom|step_19254403
+            step_19254403["greet(Example.Step.Greeter)"]
+            return_Reactor.MermaidTest.BasicReactor{"Return"}
+            step_19254403==>return_Reactor.MermaidTest.BasicReactor
+        end
+    """
+
+    assert expected == Reactor.Mermaid.to_mermaid!(BasicReactor, output: :binary)
+  end
+
+  test "reactor with input transform" do
+    defmodule ReactorWithInputTransform do
+      @moduledoc false
+      use Reactor
+
+      input :whom, transform: &String.upcase/1
+
+      step :greet, Example.Step.Greeter do
+        argument :whom, input(:whom)
+      end
+
+      return :greet
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithInputTransform
+        subgraph reactor_Reactor.MermaidTest.ReactorWithInputTransform["Reactor.MermaidTest.ReactorWithInputTransform"]
+            direction LR
+            input_47014836>"Input whom"]
+            input_47014836 -->|value|step_61395349
+            step_61395349[Transform input whom]
+            step_61395349 -->|whom|step_33109068
+            step_33109068["greet(Example.Step.Greeter)"]
+            return_Reactor.MermaidTest.ReactorWithInputTransform{"Return"}
+            step_33109068==>return_Reactor.MermaidTest.ReactorWithInputTransform
+        end
+    """
+
+    assert plain ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithInputTransform, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithInputTransform
+        subgraph reactor_Reactor.MermaidTest.ReactorWithInputTransform["Reactor.MermaidTest.ReactorWithInputTransform"]
+            direction LR
+            input_47014836>"`**Input whom**
+            `"]
+            input_47014836 -->|value|step_61395349
+            step_61395349["`**Transform input whom**
+            _&String\\.upcase/1_`"]
+            step_61395349 -->|whom|step_33109068
+            step_33109068["`**greet \\(Example.Step.Greeter\\)**
+            `"]
+            return_Reactor.MermaidTest.ReactorWithInputTransform{"Return"}
+            step_33109068==>return_Reactor.MermaidTest.ReactorWithInputTransform
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithInputTransform,
+               output: :binary,
+               describe?: true
+             )
+  end
+
+  test "reactor with inter-step dependencies" do
+    defmodule ReactorWithInterStepDependencies do
+      @moduledoc false
+      use Reactor
+
+      input :whom
+
+      step :greet, Example.Step.Greeter do
+        argument :whom, input(:whom)
+      end
+
+      step :greet_again, Example.Step.Greeter do
+        argument :whom, result(:greet)
+      end
+
+      return :greet_again
+    end
+
+    expected = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithInterStepDependencies
+        subgraph reactor_Reactor.MermaidTest.ReactorWithInterStepDependencies["Reactor.MermaidTest.ReactorWithInterStepDependencies"]
+            direction LR
+            input_54370523>"Input whom"]
+            step_56364176 -->|whom|step_91187036
+            step_91187036["greet_again(Example.Step.Greeter)"]
+            input_54370523 -->|whom|step_56364176
+            step_56364176["greet(Example.Step.Greeter)"]
+            return_Reactor.MermaidTest.ReactorWithInterStepDependencies{"Return"}
+            step_91187036==>return_Reactor.MermaidTest.ReactorWithInterStepDependencies
+        end
+    """
+
+    assert expected ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithInterStepDependencies, output: :binary)
+  end
+
+  test "reactor with around step" do
+    defmodule ReactorWithAroundStep do
+      @moduledoc false
+      use Reactor
+
+      input :whom
+
+      around :around, &around_fun/4 do
+        argument :whom, input(:whom)
+
+        step :greet, Example.Step.Greeter do
+          argument :whom, input(:whom)
+        end
+      end
+
+      defp around_fun(arguments, context, steps, callback) do
+        callback.(arguments, context, steps)
+      end
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithAroundStep
+        subgraph reactor_Reactor.MermaidTest.ReactorWithAroundStep["Reactor.MermaidTest.ReactorWithAroundStep"]
+            direction LR
+            input_83190725>"Input whom"]
+            input_83190725 -->|whom|step_114999008
+            step_114999008["around(Reactor.Step.Around)"]
+            subgraph reactor_99995062["{Reactor.Step.Around, :around}"]
+                direction LR
+                input_100859727>"Input whom"]
+                input_100859727 -->|whom|step_93379368
+                step_93379368["greet(Example.Step.Greeter)"]
+                step_93379368 -->|greet|step_17291921
+                step_17291921["{Reactor.Step.Around, :return_step}(Reactor.Step.ReturnAllArguments)"]
+                return_99995062{"Return"}
+                step_17291921==>return_99995062
+            end
+            step_114999008-->input_100859727
+            return_99995062-->step_114999008
+            return_Reactor.MermaidTest.ReactorWithAroundStep{"Return"}
+            step_114999008==>return_Reactor.MermaidTest.ReactorWithAroundStep
+        end
+    """
+
+    assert plain ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithAroundStep, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithAroundStep
+        subgraph reactor_Reactor.MermaidTest.ReactorWithAroundStep["Reactor.MermaidTest.ReactorWithAroundStep"]
+            direction LR
+            input_83190725>"`**Input whom**
+            `"]
+            input_83190725 -->|whom|step_114999008
+            step_114999008["`**around \\(Reactor.Step.Around\\)**
+            _&Reactor\\.MermaidTest\\.ReactorWithAroundStep\\.fun\\_0\\_generated\\_AB119B20591598826F6DC91738CDC793/4_`"]
+            subgraph reactor_99995062["{Reactor.Step.Around, :around}"]
+                direction LR
+                input_100859727>"`**Input whom**
+                `"]
+                input_100859727 -->|whom|step_93379368
+                step_93379368["`**greet \\(Example.Step.Greeter\\)**
+                `"]
+                step_93379368 -->|greet|step_17291921
+                step_17291921["`**\\{Reactor\\.Step\\.Around, :return\\_step\\} \\(Reactor.Step.ReturnAllArguments\\)**
+                `"]
+                return_99995062{"Return"}
+                step_17291921==>return_99995062
+            end
+            step_114999008-->input_100859727
+            return_99995062-->step_114999008
+            return_Reactor.MermaidTest.ReactorWithAroundStep{"Return"}
+            step_114999008==>return_Reactor.MermaidTest.ReactorWithAroundStep
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithAroundStep, output: :binary, describe?: true)
+  end
+
+  test "reactor with anon fun step" do
+    defmodule ReactorWithAnonFunStep do
+      @moduledoc false
+      use Reactor
+
+      step :anon do
+        run &String.upcase/1
+        compensate &String.upcase/1
+        undo &String.downcase/1
+      end
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithAnonFunStep
+        subgraph reactor_Reactor.MermaidTest.ReactorWithAnonFunStep["Reactor.MermaidTest.ReactorWithAnonFunStep"]
+            direction LR
+            step_72959588["anon(Reactor.Step.AnonFn)"]
+            return_Reactor.MermaidTest.ReactorWithAnonFunStep{"Return"}
+            step_72959588==>return_Reactor.MermaidTest.ReactorWithAnonFunStep
+        end
+    """
+
+    assert plain ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithAnonFunStep, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithAnonFunStep
+        subgraph reactor_Reactor.MermaidTest.ReactorWithAnonFunStep["Reactor.MermaidTest.ReactorWithAnonFunStep"]
+            direction LR
+            step_72959588["`**anon \\(Reactor.Step.AnonFn\\)**
+            - compensate: _&String\\.upcase/1_
+            - run: _&String\\.upcase/1_
+            - undo: _&String\\.downcase/1_`"]
+            return_Reactor.MermaidTest.ReactorWithAnonFunStep{"Return"}
+            step_72959588==>return_Reactor.MermaidTest.ReactorWithAnonFunStep
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithAnonFunStep, output: :binary, describe?: true)
+  end
+
+  test "reactor with composition" do
+    defmodule ReactorWithComposition do
+      @moduledoc false
+
+      defmodule Inner do
+        @moduledoc false
+        use Reactor
+
+        input :whom
+
+        step :greet, Example.Step.Greeter do
+          description "Perform a ritual greeting"
+          argument :whom, input(:whom)
+        end
+
+        return :greet
+      end
+
+      defmodule Outer do
+        @moduledoc false
+        use Reactor
+
+        input :first_person
+        input :second_person
+        input :third_person
+
+        compose :greet_first, Inner do
+          argument :whom, input(:first_person)
+        end
+
+        compose :greet_second, Inner do
+          argument :whom, input(:second_person)
+        end
+
+        compose :greet_third, Inner do
+          argument :whom, input(:third_person)
+        end
+      end
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithComposition.Outer
+        subgraph reactor_Reactor.MermaidTest.ReactorWithComposition.Outer["Reactor.MermaidTest.ReactorWithComposition.Outer"]
+            direction LR
+            input_86645451>"Input first_person"]
+            input_102627262>"Input second_person"]
+            input_51322880>"Input third_person"]
+            input_51322880 -->|whom|step_62090686
+            step_62090686["greet_third(Reactor.Step.Compose)"]
+            subgraph reactor_125465594["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_third}"]
+                direction LR
+                input_16861991>"Input whom"]
+                input_16861991 -->|whom|step_95294722
+                step_95294722["greet(Example.Step.Greeter)"]
+                return_125465594{"Return"}
+                step_95294722==>return_125465594
+            end
+            step_62090686-->input_16861991
+            return_125465594-->step_62090686
+            input_102627262 -->|whom|step_12286626
+            step_12286626["greet_second(Reactor.Step.Compose)"]
+            subgraph reactor_71644717["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_second}"]
+                direction LR
+                input_70137823>"Input whom"]
+                input_70137823 -->|whom|step_37146448
+                step_37146448["greet(Example.Step.Greeter)"]
+                return_71644717{"Return"}
+                step_37146448==>return_71644717
+            end
+            step_12286626-->input_70137823
+            return_71644717-->step_12286626
+            input_86645451 -->|whom|step_71715237
+            step_71715237["greet_first(Reactor.Step.Compose)"]
+            subgraph reactor_122485835["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_first}"]
+                direction LR
+                input_57209917>"Input whom"]
+                input_57209917 -->|whom|step_52726247
+                step_52726247["greet(Example.Step.Greeter)"]
+                return_122485835{"Return"}
+                step_52726247==>return_122485835
+            end
+            step_71715237-->input_57209917
+            return_122485835-->step_71715237
+            return_Reactor.MermaidTest.ReactorWithComposition.Outer{"Return"}
+            step_62090686==>return_Reactor.MermaidTest.ReactorWithComposition.Outer
+        end
+    """
+
+    assert plain ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithComposition.Outer, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithComposition.Outer
+        subgraph reactor_Reactor.MermaidTest.ReactorWithComposition.Outer["Reactor.MermaidTest.ReactorWithComposition.Outer"]
+            direction LR
+            input_86645451>"`**Input first_person**
+            `"]
+            input_102627262>"`**Input second_person**
+            `"]
+            input_51322880>"`**Input third_person**
+            `"]
+            input_51322880 -->|whom|step_62090686
+            step_62090686["`**greet\\_third \\(Reactor.Step.Compose\\)**`"]
+            subgraph reactor_125465594["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_third}"]
+                direction LR
+                input_16861991>"`**Input whom**
+                `"]
+                input_16861991 -->|whom|step_95294722
+                step_95294722["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                return_125465594{"Return"}
+                step_95294722==>return_125465594
+            end
+            step_62090686-->input_16861991
+            return_125465594-->step_62090686
+            input_102627262 -->|whom|step_12286626
+            step_12286626["`**greet\\_second \\(Reactor.Step.Compose\\)**`"]
+            subgraph reactor_71644717["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_second}"]
+                direction LR
+                input_70137823>"`**Input whom**
+                `"]
+                input_70137823 -->|whom|step_37146448
+                step_37146448["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                return_71644717{"Return"}
+                step_37146448==>return_71644717
+            end
+            step_12286626-->input_70137823
+            return_71644717-->step_12286626
+            input_86645451 -->|whom|step_71715237
+            step_71715237["`**greet\\_first \\(Reactor.Step.Compose\\)**`"]
+            subgraph reactor_122485835["{Reactor.MermaidTest.ReactorWithComposition.Inner, :greet_first}"]
+                direction LR
+                input_57209917>"`**Input whom**
+                `"]
+                input_57209917 -->|whom|step_52726247
+                step_52726247["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                return_122485835{"Return"}
+                step_52726247==>return_122485835
+            end
+            step_71715237-->input_57209917
+            return_122485835-->step_71715237
+            return_Reactor.MermaidTest.ReactorWithComposition.Outer{"Return"}
+            step_62090686==>return_Reactor.MermaidTest.ReactorWithComposition.Outer
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithComposition.Outer,
+               output: :binary,
+               describe?: true
+             )
+  end
+
+  test "reactor with group" do
+    defmodule ReactorWithGroup do
+      @moduledoc false
+      use Reactor
+
+      input :whom
+
+      group :group do
+        argument :whom, input(:whom)
+        before_all &do_before_all/3
+        after_all &do_after_all/1
+
+        step :greet, Example.Step.Greeter do
+          description "Perform a ritual greeting"
+          argument :whom, input(:whom)
+        end
+      end
+
+      defp do_before_all(args, context, steps),
+        do: {:ok, args, context, steps}
+
+      defp do_after_all(result), do: {:ok, result}
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithGroup
+        subgraph reactor_Reactor.MermaidTest.ReactorWithGroup["Reactor.MermaidTest.ReactorWithGroup"]
+            direction LR
+            input_54126149>"Input whom"]
+            input_54126149 -->|whom|step_93872833
+            step_93872833["group(Reactor.Step.Group)"]
+            subgraph reactor_66320023["{Reactor.Step.Group, :group}"]
+                direction LR
+                input_86369158>"Input whom"]
+                input_86369158 -->|whom|step_112784955
+                step_112784955["greet(Example.Step.Greeter)"]
+                step_112784955 -->|greet|step_85556533
+                step_85556533["{Reactor.Step.Group, :return_step}(Reactor.Step.ReturnAllArguments)"]
+                return_66320023{"Return"}
+                step_85556533==>return_66320023
+            end
+            step_93872833-->input_86369158
+            return_66320023-->step_93872833
+            return_Reactor.MermaidTest.ReactorWithGroup{"Return"}
+            step_93872833==>return_Reactor.MermaidTest.ReactorWithGroup
+        end
+    """
+
+    assert plain == Reactor.Mermaid.to_mermaid!(ReactorWithGroup, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithGroup
+        subgraph reactor_Reactor.MermaidTest.ReactorWithGroup["Reactor.MermaidTest.ReactorWithGroup"]
+            direction LR
+            input_54126149>"`**Input whom**
+            `"]
+            input_54126149 -->|whom|step_93872833
+            step_93872833["`**group \\(Reactor.Step.Group\\)**
+            - after: _&Reactor\\.MermaidTest\\.ReactorWithGroup\\.after\\_all\\_0\\_generated\\_03884852E6C41147D8A2F4C0B16C98F0/1_
+            - before: _&Reactor\\.MermaidTest\\.ReactorWithGroup\\.before\\_all\\_0\\_generated\\_FA2B8A4BC9AC4CB8EA4E7BC9C89643D7/3_`"]
+            subgraph reactor_66320023["{Reactor.Step.Group, :group}"]
+                direction LR
+                input_86369158>"`**Input whom**
+                `"]
+                input_86369158 -->|whom|step_112784955
+                step_112784955["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                step_112784955 -->|greet|step_85556533
+                step_85556533["`**\\{Reactor\\.Step\\.Group, :return\\_step\\} \\(Reactor.Step.ReturnAllArguments\\)**
+                `"]
+                return_66320023{"Return"}
+                step_85556533==>return_66320023
+            end
+            step_93872833-->input_86369158
+            return_66320023-->step_93872833
+            return_Reactor.MermaidTest.ReactorWithGroup{"Return"}
+            step_93872833==>return_Reactor.MermaidTest.ReactorWithGroup
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithGroup, output: :binary, describe?: true)
+  end
+
+  test "reactor with map" do
+    defmodule ReactorWithMap do
+      @moduledoc false
+      use Reactor
+
+      input :whom
+
+      map :greetings do
+        source input(:whom)
+
+        step :greet, Example.Step.Greeter do
+          description "Perform a ritual greeting"
+          argument :whom, element(:greetings)
+        end
+      end
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithMap
+        subgraph reactor_Reactor.MermaidTest.ReactorWithMap["Reactor.MermaidTest.ReactorWithMap"]
+            direction LR
+            input_70555545>"Input whom"]
+            input_70555545 -->|source|step_36016958
+            step_36016958["greetings(Reactor.Step.Map)"]
+            subgraph reactor_53997923["{Reactor.Step.Map.Mermaid, :greetings}"]
+                direction LR
+                input_119882032>"Input source"]
+                input_119882032 -->|whom|step_45902516
+                step_45902516["greet(Example.Step.Greeter)"]
+                return_53997923{"Return"}
+                step_45902516==>return_53997923
+            end
+            step_36016958-->input_119882032
+            return_53997923-->step_36016958
+            return_Reactor.MermaidTest.ReactorWithMap{"Return"}
+            step_36016958==>return_Reactor.MermaidTest.ReactorWithMap
+        end
+    """
+
+    assert plain == Reactor.Mermaid.to_mermaid!(ReactorWithMap, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithMap
+        subgraph reactor_Reactor.MermaidTest.ReactorWithMap["Reactor.MermaidTest.ReactorWithMap"]
+            direction LR
+            input_70555545>"`**Input whom**
+            `"]
+            input_70555545 -->|source|step_36016958
+            step_36016958["`**greetings \\(Reactor.Step.Map\\)**`"]
+            subgraph reactor_53997923["{Reactor.Step.Map.Mermaid, :greetings}"]
+                direction LR
+                input_119882032>"`**Input source**
+                `"]
+                input_119882032 -->|whom|step_45902516
+                step_45902516["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                return_53997923{"Return"}
+                step_45902516==>return_53997923
+            end
+            step_36016958-->input_119882032
+            return_53997923-->step_36016958
+            return_Reactor.MermaidTest.ReactorWithMap{"Return"}
+            step_36016958==>return_Reactor.MermaidTest.ReactorWithMap
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithMap, output: :binary, describe?: true)
+  end
+
+  test "reactor with switch" do
+    defmodule ReactorWithSwitch do
+      @moduledoc false
+      use Reactor
+
+      input :maybe_truthy
+
+      switch :switch do
+        on input(:maybe_truthy)
+
+        matches? &(!!&1) do
+          step :greet, Example.Step.Greeter do
+            description "Perform a ritual greeting"
+            argument :whom, value("World")
+          end
+        end
+
+        default do
+          flunk :fail, "No one to greet!"
+        end
+      end
+    end
+
+    plain = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithSwitch
+        subgraph reactor_Reactor.MermaidTest.ReactorWithSwitch["Reactor.MermaidTest.ReactorWithSwitch"]
+            direction LR
+            input_62094121>"Input maybe_truthy"]
+            input_62094121 -->|value|step_94911623
+            step_94911623["switch(Reactor.Step.Switch)"]
+            step_94911623_decision@{shape: diamond, label: "Decision for switch"}
+            step_94911623-->step_94911623_decision
+            step_94911623_decision-->step_40606384
+            step_94911623_decision-->step_69352850
+            subgraph step_40606384["default branch of switch"]
+                step_64306052["{:fail, :arguments}(Reactor.Step.ReturnAllArguments)"]
+                step_64306052 -->|arguments|step_71585845
+                value_10391594{{"`&quot;No one to greet\\!&quot;`"}}
+                value_10391594 -->|message|step_71585845
+                step_71585845["fail(Reactor.Step.Fail)"]
+                direction LR
+            end
+            subgraph step_69352850["match branch of switch"]
+                value_World{{"`&quot;World&quot;`"}}
+                value_World -->|whom|step_52846662
+                step_52846662["greet(Example.Step.Greeter)"]
+                direction LR
+            end
+            return_Reactor.MermaidTest.ReactorWithSwitch{"Return"}
+            step_94911623==>return_Reactor.MermaidTest.ReactorWithSwitch
+        end
+    """
+
+    assert plain == Reactor.Mermaid.to_mermaid!(ReactorWithSwitch, output: :binary)
+
+    expanded = """
+    flowchart LR
+        start{"Start"}
+        start==>reactor_Reactor.MermaidTest.ReactorWithSwitch
+        subgraph reactor_Reactor.MermaidTest.ReactorWithSwitch["Reactor.MermaidTest.ReactorWithSwitch"]
+            direction LR
+            input_62094121>"`**Input maybe_truthy**
+            `"]
+            input_62094121 -->|value|step_94911623
+            step_94911623["`**switch \\(Reactor.Step.Switch\\)**`"]
+            step_94911623_decision@{shape: diamond, label: "Decision for switch"}
+            step_94911623-->step_94911623_decision
+            step_94911623_decision-->step_40606384
+            step_94911623_decision-->step_69352850
+            subgraph step_40606384["default branch of switch"]
+                step_64306052["`**\\{:fail, :arguments\\} \\(Reactor.Step.ReturnAllArguments\\)**
+                `"]
+                step_64306052 -->|arguments|step_71585845
+                value_10391594{{"`&quot;No one to greet\\!&quot;`"}}
+                value_10391594 -->|message|step_71585845
+                step_71585845["`**fail \\(Reactor.Step.Fail\\)**
+                `"]
+                direction LR
+            end
+            subgraph step_69352850["`match branch of switch
+            _&Reactor\\.MermaidTest\\.ReactorWithSwitch\\.predicate\\_0\\_generated\\_E5CBC1E5147E30A8DA7DF7C06141D07E/1_`"]
+                value_World{{"`&quot;World&quot;`"}}
+                value_World -->|whom|step_52846662
+                step_52846662["`**greet \\(Example.Step.Greeter\\)**
+                Perform a ritual greeting`"]
+                direction LR
+            end
+            return_Reactor.MermaidTest.ReactorWithSwitch{"Return"}
+            step_94911623==>return_Reactor.MermaidTest.ReactorWithSwitch
+        end
+    """
+
+    assert expanded ==
+             Reactor.Mermaid.to_mermaid!(ReactorWithSwitch, output: :binary, describe?: true)
+  end
+end


### PR DESCRIPTION
Hi folks 👋 

This PR adds the ability to convert Reactors into Mermaid. It's not particularly pretty yet, but it works well enough to ship it as a first version and can be improved if required.

```mermaid
flowchart LR
        start{"Start"}
        start==>reactor_Reactor.MermaidTest.BasicReactor
        subgraph reactor_Reactor.MermaidTest.BasicReactor["Reactor.MermaidTest.BasicReactor"]
            direction LR
            input_105483575>"Input whom"]
            input_105483575 -->|whom|step_19254403
            step_19254403["greet(Example.Step.Greeter)"]
            return_Reactor.MermaidTest.BasicReactor{"Return"}
            step_19254403==>return_Reactor.MermaidTest.BasicReactor
        end
```