### PR TITLE
improvement: Include a unique `run_id` for every reactor run.

### DIFF
--- a/lib/reactor.ex
+++ b/lib/reactor.ex
@@ -153,16 +153,21 @@ defmodule Reactor do
       default: :infinity,
       doc: "The maximum number of times to allow the Reactor to loop"
     ],
-    async_option: [
+    async?: [
       type: :boolean,
       required: false,
       default: true,
       doc: "Whether to allow the Reactor to start processes"
     ],
-    concurrency_key_option: [
+    concurrency_key: [
       type: :reference,
       required: false,
       hide: true
+    ],
+    run_id: [
+      type: :any,
+      required: false,
+      doc: "A unique identifier for the Reactor run"
     ]
   ]
 

--- a/lib/reactor/executor.ex
+++ b/lib/reactor/executor.ex
@@ -61,9 +61,9 @@ defmodule Reactor.Executor do
     do: {:error, MissingReturnError.exception(reactor: reactor)}
 
   def run(reactor, inputs, context, options) when reactor.state in ~w[pending halted]a do
-    with {:ok, context} <- Executor.Hooks.init(reactor, context),
-         {:ok, reactor, state} <- Executor.Init.init(reactor, inputs, context, options) do
-      execute(reactor, state)
+    with {:ok, reactor, state} <- Executor.Init.init(reactor, inputs, context, options),
+         {:ok, context} <- Executor.Hooks.init(reactor, reactor.context) do
+      execute(%{reactor | context: context}, state)
     end
   end
 

--- a/lib/reactor/executor/hooks.ex
+++ b/lib/reactor/executor/hooks.ex
@@ -11,6 +11,7 @@ defmodule Reactor.Executor.Hooks do
     context =
       Map.put(context, :__reactor__, %{
         id: reactor.id,
+        run_id: context.run_id,
         inputs: reactor.inputs,
         middleware: reactor.middleware,
         step_count: step_count(reactor),

--- a/lib/reactor/executor/init.ex
+++ b/lib/reactor/executor/init.ex
@@ -24,6 +24,7 @@ defmodule Reactor.Executor.Init do
         reactor.context
         |> deep_merge(context)
         |> deep_merge(%{private: %{inputs: inputs}})
+        |> Map.put(:run_id, state.run_id)
 
       {:ok, %{reactor | context: context}, state}
     end

--- a/lib/reactor/executor/state.ex
+++ b/lib/reactor/executor/state.ex
@@ -21,6 +21,7 @@ defmodule Reactor.Executor.State do
             max_iterations: @defaults.max_iterations,
             pool_owner: false,
             retries: %{},
+            run_id: nil,
             skipped: MapSet.new(),
             started_at: nil,
             timeout: @defaults.timeout
@@ -37,6 +38,7 @@ defmodule Reactor.Executor.State do
           max_iterations: pos_integer() | :infinity,
           pool_owner: boolean,
           retries: %{reference() => pos_integer()},
+          run_id: any,
           skipped: MapSet.t(),
           started_at: DateTime.t(),
           timeout: pos_integer() | :infinity
@@ -54,6 +56,7 @@ defmodule Reactor.Executor.State do
     attrs
     |> maybe_set_max_concurrency()
     |> maybe_allocate_concurrency_pool()
+    |> maybe_set_run_id()
     |> Map.put(:started_at, DateTime.utc_now())
     |> then(&struct!(__MODULE__, &1))
   end
@@ -77,5 +80,13 @@ defmodule Reactor.Executor.State do
     attrs
     |> Map.put(:concurrency_key, ConcurrencyTracker.allocate_pool(attrs.max_concurrency))
     |> Map.put(:pool_owner, true)
+  end
+
+  defp maybe_set_run_id(attrs) do
+    attrs
+    |> Map.update(:run_id, make_ref(), fn
+      nil -> make_ref()
+      ref -> ref
+    end)
   end
 end

--- a/lib/reactor/executor/step_runner.ex
+++ b/lib/reactor/executor/step_runner.ex
@@ -39,6 +39,7 @@ defmodule Reactor.Executor.StepRunner do
         current_step: step,
         pid: self(),
         reactor: reactor,
+        run_id: state.run_id,
         concurrency_key: concurrency_key
       }
 


### PR DESCRIPTION
This `run_id` is mostly used in telemetry.
