### PR TITLE
chore: migrate from deprecated `igniter/2` to `igniter/1`

### DIFF
--- a/lib/mix/tasks/reactor.install.ex
+++ b/lib/mix/tasks/reactor.install.ex
@@ -11,7 +11,7 @@ if Code.ensure_loaded?(Igniter) do
 
     @doc false
     @impl Task
-    def igniter(igniter, _argv) do
+    def igniter(igniter) do
       igniter
       |> Formatter.import_dep(:reactor)
     end


### PR DESCRIPTION
Can't quite derive from commit history whether this constitutes a `chore` or `improvement` in this repo's book.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
