### PR TITLE
fix(mermaid): use TB instead of TD

### DIFF
--- a/documentation/explanation/concepts.md
+++ b/documentation/explanation/concepts.md
@@ -9,7 +9,7 @@ This guide explains the fundamental concepts that make Reactor work, providing d
 The Saga pattern provides transaction-like semantics across multiple distinct resources without requiring distributed transactions. Instead of traditional ACID properties, sagas use compensation to handle failures.
 
 ```mermaid
-graph TD
+graph TB
     subgraph "Forward Execution (Happy Path)"
         A[Step A: Reserve Inventory] --> B[Step B: Authorize Payment]
         B --> C[Step C: Create Order]

--- a/documentation/how-to/payment-processing.md
+++ b/documentation/how-to/payment-processing.md
@@ -11,7 +11,7 @@ This guide shows you how to build a robust payment processing workflow using Rea
 Here's the complete payment processing flow with error handling:
 
 ```mermaid
-flowchart TD
+flowchart TB
     Start([Order Received]) --> ValidatePayment[Validate Payment Details]
     ValidatePayment --> CheckInventory[Check Inventory]
     ValidatePayment --> ValidateAddress[Validate Shipping Address]

--- a/documentation/tutorials/01-getting-started.md
+++ b/documentation/tutorials/01-getting-started.md
@@ -17,7 +17,7 @@ A user registration workflow that validates email, hashes passwords, and creates
 Here's what we'll build - a simple user registration workflow:
 
 ```mermaid
-graph TD
+graph TB
     A[input: email] --> B[validate_email]
     A2[input: password] --> C[hash_password]
     B --> D[create_user]

--- a/lib/mix/tasks/reactor.mermaid.ex
+++ b/lib/mix/tasks/reactor.mermaid.ex
@@ -207,7 +207,7 @@ defmodule Mix.Tasks.Reactor.Mermaid do
       end)
 
     diagram = """
-    flowchart TD
+    flowchart TB
     #{Enum.join(diagrams, "\n\n")}
     """
 
@@ -219,7 +219,7 @@ defmodule Mix.Tasks.Reactor.Mermaid do
   defp indent_diagram(diagram) do
     diagram
     |> String.split("\n")
-    # Remove the "flowchart TD" line
+    # Remove the "flowchart TB" line
     |> Enum.drop(1)
     |> Enum.map_join("\n", &("  " <> &1))
   end

--- a/lib/reactor/mermaid/utils.ex
+++ b/lib/reactor/mermaid/utils.ex
@@ -81,7 +81,7 @@ defmodule Reactor.Mermaid.Utils do
 
   @doc "Convert the direction atom into a mermaid direction"
   @spec direction(atom) :: String.t()
-  def direction(:top_to_bottom), do: "TD"
+  def direction(:top_to_bottom), do: "TB"
   def direction(:bottom_to_top), do: "BT"
   def direction(:left_to_right), do: "LR"
   def direction(:right_to_left), do: "RL"


### PR DESCRIPTION
TD (top down) is an alias for TB (top to bottom) in `flowchart`, but the alias is not present in subgraphs.

See https://github.com/mermaid-js/mermaid/issues/4229 for more details.

In reactors like the `UserRegistration` example, this results in broken diagrams.

This change replaces `TD` with `TB`, allowing flowcharts and subgraphs to function properly with a direction value of `:top_to_bottom`.

With TD:
![Screenshot 2025-06-26 at 7 45 46 AM](https://github.com/user-attachments/assets/f406e50f-45a7-4ac3-8073-e7297da81f3c)

With TB:
![Screenshot 2025-06-26 at 7 45 32 AM](https://github.com/user-attachments/assets/e6c6aca0-c65d-4c3e-adbf-9b1c0cb7870b)


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
