### PR TITLE
fix(mermaid): trim whitespace from module names to prevent :nofile errors

### DIFF
--- a/lib/mix/tasks/reactor.mermaid.ex
+++ b/lib/mix/tasks/reactor.mermaid.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Reactor.Mermaid do
   end
 
   defp try_load_module(module) do
-    module = Module.concat([module])
+    module = Module.concat([String.trim(module)])
 
     case Code.ensure_loaded(module) do
       {:module, module} ->

--- a/test/mix/tasks/reactor_mermaid_test.exs
+++ b/test/mix/tasks/reactor_mermaid_test.exs
@@ -1,0 +1,65 @@
+defmodule Mix.Tasks.Reactor.MermaidTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Reactor.Mermaid
+
+  describe "run/1" do
+    test "handles module names with leading whitespace" do
+      # Test that module names with leading whitespace are properly trimmed
+      output =
+        capture_io(fn ->
+          Mermaid.run([" Example.BasicReactor", "--format", "copy"])
+        end)
+
+      assert output =~ "✅ Mermaid diagram for copy-paste:"
+      assert output =~ "flowchart"
+    end
+
+    test "handles module names with trailing whitespace" do
+      # Test that module names with trailing whitespace are properly trimmed
+      output =
+        capture_io(fn ->
+          Mermaid.run(["Example.BasicReactor ", "--format", "copy"])
+        end)
+
+      assert output =~ "✅ Mermaid diagram for copy-paste:"
+      assert output =~ "flowchart"
+    end
+
+    test "handles module names with both leading and trailing whitespace" do
+      # Test that module names with both leading and trailing whitespace are properly trimmed
+      output =
+        capture_io(fn ->
+          Mermaid.run([" Example.BasicReactor ", "--format", "copy"])
+        end)
+
+      assert output =~ "✅ Mermaid diagram for copy-paste:"
+      assert output =~ "flowchart"
+    end
+
+    test "handles module names with tabs and other whitespace characters" do
+      # Test that module names with various whitespace characters are properly trimmed
+      output =
+        capture_io(fn ->
+          Mermaid.run(["\t Example.BasicReactor\n ", "--format", "copy"])
+        end)
+
+      assert output =~ "✅ Mermaid diagram for copy-paste:"
+      assert output =~ "flowchart"
+    end
+
+    test "works with clean module names (no regression)" do
+      # Test that clean module names still work as expected
+      output =
+        capture_io(fn ->
+          Mermaid.run(["Example.BasicReactor", "--format", "copy"])
+        end)
+
+      assert output =~ "✅ Mermaid diagram for copy-paste:"
+      assert output =~ "flowchart"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes issue where `mix reactor.mermaid` would fail with `:nofile` error when module names contained leading or trailing whitespace
- Adds comprehensive tests to verify the fix works with various whitespace scenarios

## Test plan

- [x] Added tests for module names with leading whitespace
- [x] Added tests for module names with trailing whitespace  
- [x] Added tests for module names with both leading and trailing whitespace
- [x] Added tests for module names with tabs and other whitespace characters
- [x] Added regression test to ensure clean module names still work
- [x] Verified all existing tests still pass
- [x] Verified the fix resolves the original issue described in #251

Closes #251