### PR TITLE
fix: correct current_try increment during step retries

### DIFF
--- a/lib/reactor/executor/async.ex
+++ b/lib/reactor/executor/async.ex
@@ -148,7 +148,7 @@ defmodule Reactor.Executor.Async do
       reactor
       |> drop_from_plan(task)
 
-    if Map.get(state.retries, step.ref) >= step.max_retries do
+    if Map.get(state.retries, step.ref) > step.max_retries do
       error =
         error ||
           RetriesExceededError.exception(
@@ -223,7 +223,7 @@ defmodule Reactor.Executor.Async do
   end
 
   defp increment_retries(state, step) do
-    %{state | retries: Map.update(state.retries, step.ref, 0, &(&1 + 1))}
+    %{state | retries: Map.update(state.retries, step.ref, 1, &(&1 + 1))}
   end
 
   defp drop_from_plan(reactor, step) do

--- a/lib/reactor/executor/sync.ex
+++ b/lib/reactor/executor/sync.ex
@@ -32,7 +32,7 @@ defmodule Reactor.Executor.Sync do
   defp handle_completed_step(reactor, state, step, {:retry, error}) do
     state = increment_retries(state, step)
 
-    if Map.get(state.retries, step.ref) >= step.max_retries do
+    if Map.get(state.retries, step.ref) > step.max_retries do
       reactor = drop_from_plan(reactor, step)
 
       error =
@@ -89,7 +89,7 @@ defmodule Reactor.Executor.Sync do
   end
 
   defp increment_retries(state, step) do
-    %{state | retries: Map.update(state.retries, step.ref, 0, &(&1 + 1))}
+    %{state | retries: Map.update(state.retries, step.ref, 1, &(&1 + 1))}
   end
 
   defp drop_from_plan(reactor, step) do

--- a/test/reactor/executor/async_test.exs
+++ b/test/reactor/executor/async_test.exs
@@ -211,7 +211,7 @@ defmodule Reactor.Executor.AsyncTest do
       refute is_map_key(state.retries, doable.ref)
 
       assert {_, _reactor, state} = handle_completed_steps(reactor, state)
-      assert state.retries[doable.ref] == 0
+      assert state.retries[doable.ref] == 1
     end
 
     test "when one of the steps asks to retry (again), it increments the retry count for the step",

--- a/test/reactor/executor/compensation_test.exs
+++ b/test/reactor/executor/compensation_test.exs
@@ -65,12 +65,6 @@ defmodule Reactor.Executor.CompensationTest do
              {:run_error, %RunStepError{error: :fail}, 0},
              {:compensate_start, %RunStepError{error: :fail}, 0},
              :compensate_retry,
-             # Current behavior (current_try does not immediately increment).
-             # Uncomment to make the test pass:
-            #  {:run_start, _, 0},
-            #  {:run_error, %RunStepError{error: :fail}, 0},
-            #  {:compensate_start, %RunStepError{error: :fail}, 0},
-            #  :compensate_retry,
              {:run_start, _, 1},
              {:run_error, %RunStepError{error: :fail}, 1},
              {:compensate_start, %RunStepError{error: :fail}, 1},

--- a/test/reactor/executor/compensation_test.exs
+++ b/test/reactor/executor/compensation_test.exs
@@ -1,0 +1,83 @@
+defmodule Reactor.Executor.CompensationTest do
+  use ExUnit.Case, async: true
+
+  alias Reactor.Error.Invalid.RunStepError
+
+  defmodule EventMiddleware do
+    use Reactor.Middleware
+
+    @moduledoc false
+    def event(event, _step, context) do
+      Agent.update(context.event_agent, fn events ->
+        [append_elem(event, context.current_try) | events]
+      end)
+
+      :ok
+    end
+
+    defp append_elem(event, elem) when is_tuple(event) do
+      event
+      |> Tuple.to_list()
+      |> Kernel.++([elem])
+      |> List.to_tuple()
+    end
+
+    defp append_elem(event, _), do: event
+  end
+
+  def run(reactor, args, opts \\ []) do
+    {:ok, pid} = Agent.start_link(fn -> [] end)
+
+    reactor.reactor()
+    |> Reactor.Builder.ensure_middleware!(EventMiddleware)
+    |> Reactor.run(args, %{event_agent: pid}, opts)
+
+    Agent.get(pid, fn events -> Enum.reverse(events) end)
+  end
+
+  defmodule CompensateReactor do
+    @moduledoc false
+    use Reactor
+
+    input :compensation_result
+
+    step :fail do
+      argument :compensation_result, input(:compensation_result)
+      max_retries 3
+
+      run fn _, %{current_try: current_try} ->
+        if current_try > 1 do
+          {:ok, :done}
+        else
+          {:error, :fail}
+        end
+      end
+
+      compensate fn _, arguments, _ ->
+        arguments.compensation_result
+      end
+    end
+  end
+
+  test "increments current_try" do
+    assert [
+             {:run_start, _, 0},
+             {:run_error, %RunStepError{error: :fail}, 0},
+             {:compensate_start, %RunStepError{error: :fail}, 0},
+             :compensate_retry,
+             # Current behavior (current_try does not immediately increment).
+             # Uncomment to make the test pass:
+            #  {:run_start, _, 0},
+            #  {:run_error, %RunStepError{error: :fail}, 0},
+            #  {:compensate_start, %RunStepError{error: :fail}, 0},
+            #  :compensate_retry,
+             {:run_start, _, 1},
+             {:run_error, %RunStepError{error: :fail}, 1},
+             {:compensate_start, %RunStepError{error: :fail}, 1},
+             :compensate_retry,
+             {:run_start, _, 2},
+             {:run_complete, :done, 2}
+           ] =
+             run(CompensateReactor, %{compensation_result: :retry}, async?: false)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Fix bug where \`current_try\` was not properly incremented during step retries, causing incorrect attempt numbering in retry scenarios.

## Problem

The \`current_try\` context value was not being incremented correctly during step retries:
- First attempt: \`current_try = 0\` ✓
- First retry: \`current_try = 0\` ❌ (should be 1)  
- Second retry: \`current_try = 1\` ❌ (should be 2)

This was caused by a bug in the \`increment_retries\` function using an incorrect default value in \`Map.update/4\`.

## Root Cause

The issue was in both \`lib/reactor/executor/async.ex\` and \`lib/reactor/executor/sync.ex\`:

\`\`\`elixir
# Incorrect - sets retry count to 0 for first retry
Map.update(state.retries, step.ref, 0, &(&1 + 1))

# Correct - sets retry count to 1 for first retry  
Map.update(state.retries, step.ref, 1, &(&1 + 1))
\`\`\`

Additionally, the retry limit check used \`>=\` instead of \`>\`, which prevented the correct number of retries when \`max_retries\` was set.

## Solution

1. **Fixed \`increment_retries\` function**: Changed default value from \`0\` to \`1\` in \`Map.update/4\`
2. **Updated retry limit check**: Changed from \`>=\` to \`>\` for correct \`max_retries\` semantics
3. **Added comprehensive test**: Includes test case contributed by @skanderm that demonstrates the fix

## Changes

- \`lib/reactor/executor/async.ex\`: Fix increment_retries and retry limit check
- \`lib/reactor/executor/sync.ex\`: Fix increment_retries and retry limit check  
- \`test/reactor/executor/async_test.exs\`: Update test expectation for new behavior
- \`test/reactor/executor/compensation_test.exs\`: Add failing test case from @skanderm

## Test Results

✅ All existing tests pass  
✅ New test case passes with correct \`current_try\` progression  
✅ No regressions in retry behavior  
✅ \`mix check\` passes all quality checks

The fix ensures \`current_try\` correctly progresses: 0 → 1 → 2 instead of the previous incorrect 0 → 0 → 1 progression.

Includes the reproduction test from https://github.com/ash-project/reactor/pull/243