### PR TITLE
feat: Allow Reactors to be able to be undone after successful completion

### DIFF
--- a/lib/reactor/executor/init.ex
+++ b/lib/reactor/executor/init.ex
@@ -8,7 +8,12 @@ defmodule Reactor.Executor.Init do
   import Reactor.Utils
 
   @doc false
-  @spec init(Reactor.t(), Reactor.inputs(), Reactor.context(), Reactor.options()) ::
+  @spec init(
+          Reactor.t(),
+          Reactor.inputs(),
+          Reactor.context(),
+          Reactor.run_options() | Reactor.undo_options()
+        ) ::
           {:ok, Reactor.t(), state :: map} | {:error, any}
   def init(reactor, _inputs, _context, _options) when not is_reactor(reactor),
     do: {:error, ArgumentError.exception(message: "`reactor` is not a Reactor.")}
@@ -24,7 +29,7 @@ defmodule Reactor.Executor.Init do
         reactor.context
         |> deep_merge(context)
         |> deep_merge(%{private: %{inputs: inputs}})
-        |> Map.put(:run_id, state.run_id)
+        |> Map.put_new(:run_id, state.run_id)
 
       {:ok, %{reactor | context: context}, state}
     end

--- a/lib/reactor/executor/state.ex
+++ b/lib/reactor/executor/state.ex
@@ -9,7 +9,8 @@ defmodule Reactor.Executor.State do
     async?: true,
     halt_timeout: 5000,
     max_iterations: :infinity,
-    timeout: :infinity
+    timeout: :infinity,
+    fully_reversible?: false
   }
 
   defstruct async?: @defaults.async?,
@@ -24,7 +25,8 @@ defmodule Reactor.Executor.State do
             run_id: nil,
             skipped: MapSet.new(),
             started_at: nil,
-            timeout: @defaults.timeout
+            timeout: @defaults.timeout,
+            fully_reversible?: @defaults.fully_reversible?
 
   alias Reactor.{Executor.ConcurrencyTracker, Step}
 

--- a/test/reactor_test.exs
+++ b/test/reactor_test.exs
@@ -52,5 +52,59 @@ defmodule ReactorTest do
 
       assert {:ok, "McFly Marty"} = Reactor.run(reactor, name: "Marty McFly")
     end
+
+    test "it can return successful reactors" do
+      assert {:ok, "Marty McFly", reactor} =
+               Reactor.run(BasicReactor, %{name: "McFly Marty"}, %{}, fully_reversible?: true)
+
+      assert reactor.state == :successful
+    end
+  end
+
+  describe "undo/2" do
+    defmodule UndoableReactor do
+      use Reactor
+
+      input :agent
+
+      step :push_a do
+        argument :agent, input(:agent)
+        run &push(&1, :a)
+        undo &undo/2
+      end
+
+      step :push_b do
+        wait_for :push_a
+        argument :agent, input(:agent)
+        run &push(&1, :b)
+        undo &undo/2
+      end
+
+      return :push_b
+
+      def push(args, value) do
+        Agent.update(args.agent, fn list -> [value | list] end)
+        {:ok, value}
+      end
+
+      def undo(value, args) do
+        Agent.update(args.agent, fn list -> List.delete(list, value) end)
+
+        :ok
+      end
+    end
+
+    test "previously successful reactors can be undone" do
+      {:ok, pid} = Agent.start_link(fn -> [:z] end)
+
+      assert {:ok, :b, reactor} =
+               Reactor.run(UndoableReactor, %{agent: pid}, %{}, fully_reversible?: true)
+
+      assert [:b, :a, :z] = Agent.get(pid, &Function.identity/1)
+
+      assert :ok = Reactor.undo(reactor, %{})
+
+      assert [:z] = Agent.get(pid, &Function.identity/1)
+    end
   end
 end


### PR DESCRIPTION
This change:

1.  adds the `fully_reversible?` option to `Reactor.run/4` which changes the return behaviour to include the completed Reactor struct in a successful result.
2. adds the `Reactor.undo/3` function which allows the reversal of a previously successful Reactor.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
