### PR TITLE
fix: Add stacktrace to exception

### DIFF
--- a/lib/reactor/executor/step_runner.ex
+++ b/lib/reactor/executor/step_runner.ex
@@ -161,7 +161,7 @@ defmodule Reactor.Executor.StepRunner do
     |> handle_run_result(reactor, step, arguments, context)
   rescue
     reason ->
-      error = RunStepError.exception(step: step, error: reason)
+      error = RunStepError.exception(step: step, error: reason, stacktrace: __STACKTRACE__)
       Hooks.event(reactor, {:run_error, error}, step, context)
 
       maybe_compensate(reactor, step, error, arguments, context)

--- a/lib/reactor/step/anon_fn.ex
+++ b/lib/reactor/step/anon_fn.ex
@@ -29,8 +29,6 @@ defmodule Reactor.Step.AnonFn do
       {m, f, a} when is_atom(m) and is_atom(f) and is_list(a) ->
         apply(m, f, [arguments, context] ++ a)
     end
-  rescue
-    error -> {:error, error}
   end
 
   @doc false

--- a/test/reactor/step/anon_fn_test.exs
+++ b/test/reactor/step/anon_fn_test.exs
@@ -19,13 +19,6 @@ defmodule Reactor.Step.AnonFnTest do
     test "it can handle an MFA" do
       assert :marty = run(%{first_name: :marty}, %{}, run: {__MODULE__, :example, []})
     end
-
-    test "it rescues errors" do
-      fun = fn _, _ -> raise "Marty" end
-
-      assert {:error, error} = run(%{}, %{}, run: fun)
-      assert Exception.message(error) =~ "Marty"
-    end
   end
 
   def example(arguments, _context) do

--- a/test/reactor/step/error_test.exs
+++ b/test/reactor/step/error_test.exs
@@ -1,0 +1,26 @@
+defmodule Reactor.Step.ErrorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule ErrorStep do
+    @moduledoc false
+    use Reactor.Step
+
+    @impl true
+    def run(_argument, _context, _options) do
+      raise "This step always returns an error"
+    end
+  end
+
+  defmodule ErrorReactor do
+    @moduledoc false
+    use Reactor
+
+    step :named_step, ErrorStep
+  end
+
+  test "it has stacktrace available in error" do
+    {:error, %{errors: [%{stacktrace: stacktrace}]}} = Reactor.run(ErrorReactor, %{})
+    assert stacktrace.stacktrace |> Enum.any?(&match?({ErrorStep, :run, 3, _}, &1))
+  end
+end

--- a/test/reactor/step/error_test.exs
+++ b/test/reactor/step/error_test.exs
@@ -19,8 +19,30 @@ defmodule Reactor.Step.ErrorTest do
     step :named_step, ErrorStep
   end
 
+  defmodule AnonErrorReactor do
+    @moduledoc false
+    use Reactor
+
+    step :step do
+      run fn _, _ ->
+        raise "This always returns an error"
+      end
+    end
+  end
+
   test "it has stacktrace available in error" do
     {:error, %{errors: [%{stacktrace: stacktrace}]}} = Reactor.run(ErrorReactor, %{})
-    assert stacktrace.stacktrace |> Enum.any?(&match?({ErrorStep, :run, 3, _}, &1))
+    [{ErrorStep, :run, 3, opts} | _] = stacktrace.stacktrace
+
+    assert Keyword.get(opts, :line) == 11
+    assert Keyword.get(opts, :file) == ~c"test/reactor/step/error_test.exs"
+  end
+
+  test "it has stacktrace available when running anonymous step" do
+    {:error, %{errors: [%{stacktrace: stacktrace}]}} = Reactor.run(AnonErrorReactor, %{})
+    [{AnonErrorReactor, _anon_fn_name, _arity, opts} | _] = stacktrace.stacktrace
+
+    assert Keyword.get(opts, :line) == 28
+    assert Keyword.get(opts, :file) == ~c"test/reactor/step/error_test.exs"
   end
 end


### PR DESCRIPTION
When an exception occured inside of a Reactor.Step it would not show the stacktrace but only the error message. This change includes the stacktrace in the exception and also adds a test that validates this.

This only works for "named" steps. The easiest way to also make it work for anonymous steps would be to remove the rescue clause from the `AnonFn.run/3` function:
https://github.com/ash-project/reactor/blob/df74431bd1bc62a1c8935f86a65fc86abe13a9f4/lib/reactor/step/anon_fn.ex#L32C1-L33C29

Changing the `AnonFn.run/3` would be a breaking change so I wanted to discuss that first.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
