### PR TITLE
fix: set proper class for reactor errors

### DIFF
--- a/lib/reactor/error/internal.ex
+++ b/lib/reactor/error/internal.ex
@@ -8,7 +8,7 @@ defmodule Reactor.Error.Internal do
   The [Splode error class](e:splode:get-started-with-splode.html#error-classes)
   for Reactor-caused errors.
   """
-  use Reactor.Error, fields: [:errors], class: :reactor
+  use Reactor.Error, fields: [:errors], class: :internal
 
   @doc false
   @impl true

--- a/lib/reactor/error/invalid.ex
+++ b/lib/reactor/error/invalid.ex
@@ -9,7 +9,7 @@ defmodule Reactor.Error.Invalid do
   for user-caused errors.
   """
 
-  use Reactor.Error, fields: [:errors], class: :unknown
+  use Reactor.Error, fields: [:errors], class: :invalid
 
   @doc false
   @impl true


### PR DESCRIPTION
# Contributor checklist

Error classes having the correct class atom helps with merging errors from different splode's together.