### PR TITLE
fix: pass unwrapped error to `backoff/4` on bare `:retry` from `compensate/4`

### DIFF
--- a/lib/reactor/executor/step_runner.ex
+++ b/lib/reactor/executor/step_runner.ex
@@ -288,7 +288,7 @@ defmodule Reactor.Executor.StepRunner do
   defp handle_compensate_result(:retry, reactor, step, arguments, context, reason) do
     Hooks.event(reactor, :compensate_retry, step, context)
 
-    case Step.backoff(step, reason, arguments, context) do
+    case Step.backoff(step, reason.error, arguments, context) do
       delay when is_integer(delay) and delay > 0 -> {:backoff, delay, {:retry, reason}}
       _ -> {:retry, reason}
     end

--- a/test/reactor/executor/step_runner_test.exs
+++ b/test/reactor/executor/step_runner_test.exs
@@ -242,7 +242,7 @@ defmodule Reactor.Executor.StepRunnerTest do
       Example.Step.Compensable
       |> stub(:run, fn _, _, _ -> {:error, :doc} end)
       |> stub(:compensate, fn :doc, _, _, _ -> :retry end)
-      |> stub(:backoff, fn _, _, _, _ -> 100 end)
+      |> stub(:backoff, fn :doc, _, _, _ -> 100 end)
 
       assert {:backoff, 100, {:retry, %RunStepError{error: :doc}}} =
                run(reactor, state, step, nil)


### PR DESCRIPTION
## Summary

- When `compensate/4` returns bare `:retry`, `backoff/4` was receiving the `RunStepError` wrapper instead of the inner error. All other code paths pass the unwrapped error, so this was inconsistent and meant pattern matching on the error in `backoff/4` wouldn't work as expected.
- Tightened the existing test to assert `backoff/4` receives the unwrapped error.

Closes #300, closes #301

## Test plan

- [x] Existing test updated to assert unwrapped error is passed
- [x] Full test suite passes (331 tests, 8 doctests)
- [x] `mix check --no-retry` passes all 13 checks