### PR TITLE
fix: avoid spinning when waiting for retry backoffs

### DIFF
--- a/lib/reactor/executor.ex
+++ b/lib/reactor/executor.ex
@@ -112,9 +112,13 @@ defmodule Reactor.Executor do
          {:continue, reactor, state} <- run_ready_sync_step(reactor, state, ready_steps),
          {:continue, reactor, state} <- maybe_run_any_step_sync(reactor, state, ready_steps),
          {:continue, reactor, state} <- prune_expired_backoffs(reactor, state),
-         {:continue, reactor} <- all_done(reactor) do
+         {:continue, reactor} <- all_done(reactor),
+         {:continue, reactor, state} <- wait_for_next_backoff(reactor, state, ready_steps) do
       execute(reactor, subtract_iteration(state))
     else
+      {:spin, reactor, state} ->
+        execute(reactor, state)
+
       {:recurse, reactor, state} ->
         execute(reactor, subtract_iteration(state))
 
@@ -327,6 +331,67 @@ defmodule Reactor.Executor do
 
       to_remove ->
         {:recurse, %{reactor | plan: Multigraph.delete_vertices(reactor.plan, to_remove)}, state}
+    end
+  end
+
+  # Ready steps may be waiting for a shared concurrency slot, whose release does
+  # not emit a notification, so allow the executor to keep polling for one.
+  defp wait_for_next_backoff(reactor, state, [_step | _steps]),
+    do: {:continue, reactor, state}
+
+  # While async tasks are running, `Executor.Async` already waits for their
+  # completion, so no additional backoff wait is needed here.
+  defp wait_for_next_backoff(reactor, state, [])
+       when map_size(state.current_tasks) > 0,
+       do: {:continue, reactor, state}
+
+  # There are not enough iterations left to prune the backoff and retry the step.
+  # Skip sleeping so `execute/2` consumes the final iteration and halts.
+  defp wait_for_next_backoff(reactor, %{max_iterations: 1} = state, []),
+    do: {:continue, reactor, state}
+
+  # At this point there are no ready steps or running tasks. In a valid acyclic
+  # plan, the only remaining vertex whose state can change with time is a
+  # backoff, so its earliest expiry is the next opportunity to make progress.
+  defp wait_for_next_backoff(reactor, state, []) do
+    reactor.plan
+    |> Multigraph.vertices()
+    |> Enum.reduce(nil, fn
+      %Backoff{expires_at: expires_at}, nil -> expires_at
+      %Backoff{expires_at: expires_at}, earliest -> min(expires_at, earliest)
+      _vertex, earliest -> earliest
+    end)
+    |> case do
+      nil ->
+        {:continue, reactor, state}
+
+      expires_at ->
+        expires_at
+        |> backoff_wait_time(state)
+        |> Process.sleep()
+
+        {:spin, reactor, state}
+    end
+  end
+
+  # Periodically re-evaluate the executor state so an overlooked condition which
+  # can make progress cannot leave the process sleeping for an excessive period.
+  @max_backoff_sleep 1_000
+  defp backoff_wait_time(expires_at, state) do
+    wait_time = max(expires_at - System.monotonic_time(:millisecond), 0)
+
+    # Do not sleep past the Reactor timeout; wake so the next executor iteration
+    # can halt the run promptly.
+    case state.timeout do
+      :infinity ->
+        min(wait_time, @max_backoff_sleep)
+
+      timeout ->
+        elapsed = DateTime.diff(DateTime.utc_now(), state.started_at, :millisecond)
+
+        wait_time
+        |> min(max(timeout - elapsed, 0))
+        |> min(@max_backoff_sleep)
     end
   end
 

--- a/lib/reactor/executor/backoff.ex
+++ b/lib/reactor/executor/backoff.ex
@@ -11,7 +11,7 @@ defmodule Reactor.Executor.Backoff do
 
   @type t :: %__MODULE__{
           ref: reference(),
-          expires_at: pos_integer()
+          expires_at: integer()
         }
 
   @doc """

--- a/test/reactor/executor_test.exs
+++ b/test/reactor/executor_test.exs
@@ -5,7 +5,7 @@
 
 defmodule Reactor.ExecutorTest do
   @moduledoc false
-  alias Reactor.Executor.ConcurrencyTracker
+  alias Reactor.{Builder, Executor.ConcurrencyTracker}
   use ExUnit.Case, async: true
   use Mimic
 
@@ -580,6 +580,179 @@ defmodule Reactor.ExecutorTest do
       elapsed = end_time - start_time
 
       assert elapsed < 100
+    end
+
+    test "the executor does not spin while waiting for a retry backoff" do
+      test_pid = self()
+
+      Example.Step.Doable
+      |> expect(:run, 2, fn
+        _arguments, %{current_try: 0}, _options -> :retry
+        _arguments, %{current_try: 1}, _options -> {:ok, :finished}
+      end)
+      |> expect(:backoff, fn _reason, _arguments, _context, _options ->
+        send(test_pid, {:backoff_started, self()})
+
+        receive do
+          :start_backoff ->
+            send(test_pid, :backoff_returning)
+            500
+        end
+      end)
+
+      task =
+        Task.async(fn ->
+          Reactor.run(RetryReactor, %{}, %{}, async?: false)
+        end)
+
+      assert_receive {:backoff_started, executor_pid}, 500
+      assert executor_pid == task.pid
+
+      send(executor_pid, :start_backoff)
+      assert_receive :backoff_returning, 500
+
+      Process.sleep(10)
+
+      assert [status: :waiting, reductions: reductions_before] =
+               Process.info(task.pid, [:status, :reductions])
+
+      Process.sleep(50)
+
+      assert [status: :waiting, reductions: reductions_after] =
+               Process.info(task.pid, [:status, :reductions])
+
+      assert {:ok, :finished} = Task.await(task, 1_000)
+
+      # A suspended process should accrue almost no reductions. This generous ceiling
+      # allows for the executor finishing its backoff setup after sending the signal.
+      assert reductions_after - reductions_before < 100_000
+    end
+
+    test "waiting for a retry backoff does not exhaust the iteration limit" do
+      Example.Step.Doable
+      |> expect(:run, 2, fn
+        _arguments, %{current_try: 0}, _options -> :retry
+        _arguments, %{current_try: 1}, _options -> {:ok, :finished}
+      end)
+      |> expect(:backoff, fn _reason, _arguments, _context, _options -> 50 end)
+
+      assert {:ok, :finished} =
+               Reactor.run(RetryReactor, %{}, %{}, async?: false, max_iterations: 4)
+    end
+
+    test "the executor does not wait when the iteration limit cannot reach the retry" do
+      Example.Step.Doable
+      |> expect(:run, fn _arguments, %{current_try: 0}, _options -> :retry end)
+      |> expect(:backoff, fn _reason, _arguments, _context, _options -> 1_000 end)
+
+      task =
+        Task.async(fn ->
+          Reactor.run(RetryReactor, %{}, %{}, async?: false, max_iterations: 2)
+        end)
+
+      assert {:halted, _reactor} = Task.await(task, 250)
+    end
+
+    test "reactor timeout interrupts waiting for a retry backoff" do
+      test_pid = self()
+
+      Example.Step.Doable
+      |> expect(:run, fn _arguments, %{current_try: 0}, _options -> :retry end)
+      |> expect(:backoff, fn _reason, _arguments, _context, _options ->
+        send(test_pid, :backoff_started)
+        500
+      end)
+
+      task =
+        Task.async(fn ->
+          Reactor.run(RetryReactor, %{}, %{}, async?: false, timeout: 50)
+        end)
+
+      assert_receive :backoff_started, 500
+      assert {:halted, _reactor} = Task.await(task, 250)
+    end
+
+    test "active async tasks prevent sleeping until a retry backoff expires" do
+      test_pid = self()
+
+      backoff_step =
+        {Reactor.Step.AnonFn,
+         run: fn _arguments, %{current_try: 0} ->
+           :retry
+         end,
+         backoff: fn _reason, _arguments, _context ->
+           send(test_pid, {:backoff_started, self()})
+
+           receive do
+             :start_backoff ->
+               send(test_pid, :backoff_returning)
+               1_000
+           end
+         end}
+
+      halt_step =
+        {Reactor.Step.AnonFn,
+         run: fn _arguments, _context ->
+           send(test_pid, {:halt_step_started, self()})
+
+           receive do
+             :finish -> {:halt, :finished}
+           end
+         end}
+
+      reactor =
+        Builder.new()
+        |> Builder.add_step!(:backoff, backoff_step, [], max_retries: 1)
+        |> Builder.add_step!(:halt, halt_step)
+        |> Builder.return!(:backoff)
+
+      task = Task.async(fn -> Reactor.run(reactor) end)
+
+      assert_receive {:halt_step_started, halt_step_pid}, 500
+      assert_receive {:backoff_started, backoff_step_pid}, 500
+
+      send(backoff_step_pid, :start_backoff)
+      assert_receive :backoff_returning, 500
+
+      # Let the executor collect the backoff result and pass through another
+      # async-task polling window before completing the remaining task.
+      Process.sleep(250)
+
+      send(halt_step_pid, :finish)
+
+      assert {:halted, _reactor} = Task.await(task, 500)
+    end
+
+    test "the executor waits for the earliest retry backoff" do
+      test_pid = self()
+
+      step = fn name, delay ->
+        {Reactor.Step.AnonFn,
+         run: fn
+           _arguments, %{current_try: 0} ->
+             :retry
+
+           _arguments, %{current_try: 1} ->
+             send(test_pid, {:retried, name})
+             {:ok, name}
+         end,
+         backoff: fn _reason, _arguments, _context -> delay end}
+      end
+
+      reactor =
+        Builder.new()
+        |> Builder.add_step!(:short, step.(:short, 100), [], max_retries: 1)
+        |> Builder.add_step!(:long, step.(:long, 1_000), [], max_retries: 1)
+        |> Builder.return!(:short)
+
+      task =
+        Task.async(fn ->
+          Reactor.run(reactor, %{}, %{}, async?: false)
+        end)
+
+      assert_receive {:retried, :short}, 400
+      refute_receive {:retried, :long}, 100
+      assert {:ok, :short} = Task.await(task, 1_000)
     end
   end
 end


### PR DESCRIPTION
## Summary

1. The executor can now sleep until the earliest retry backoff expires, after ensuring no other work can make progress.
2. Sleep duration isn't indefinite; I limited it to `1s` arbitrarily. My reasoning is that it's safer to do a few extraneous spins than never continue the loop.
3. Changed `Backoff.expires_at` type from `pos_integer()` to `integer()` because [`System.monotonic_time()`](https://elixir.hexdocs.pm/System.html#monotonic_time/0) can theoretically be negative.
4. Waiting for a retry backoff does not exhaust the iteration limit - there’s a test for that added as well. Formally this is a breaking change but I doubt it’s one practically, otherwise people would notice spinning earlier and complain about it.  
5. Added several tests for measuring busy-spinning and some corner cases I identified.

Fixes #321

## Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
