### PR TITLE
fix: await in-flight async steps when a step halts the reactor

### DIFF
--- a/lib/reactor/executor.ex
+++ b/lib/reactor/executor.ex
@@ -160,7 +160,6 @@ defmodule Reactor.Executor do
 
   defp maybe_timeout(reactor, state) do
     if DateTime.diff(DateTime.utc_now(), state.started_at, :millisecond) >= state.timeout do
-      {reactor, _status} = Executor.Async.collect_remaining_tasks_for_shutdown(reactor, state)
       {:halt, reactor, state}
     else
       {:continue, reactor, state}

--- a/lib/reactor/executor.ex
+++ b/lib/reactor/executor.ex
@@ -125,7 +125,8 @@ defmodule Reactor.Executor do
       {:undo, reactor, state} ->
         handle_undo(reactor, state)
 
-      {:halt, reactor, _state} ->
+      {:halt, reactor, state} ->
+        {reactor, state} = Executor.Async.collect_remaining_tasks_for_shutdown(reactor, state)
         maybe_release_pool(state)
 
         case Executor.Hooks.halt(reactor, reactor.context) do

--- a/lib/reactor/executor/async.ex
+++ b/lib/reactor/executor/async.ex
@@ -135,22 +135,7 @@ defmodule Reactor.Executor.Async do
       |> maybe_store_undo(step, value, state)
       |> maybe_store_intermediate_result(step, value)
 
-    reactor =
-      case Enum.split_with(new_steps, &(&1.name == step.name)) do
-        {[], new_steps} ->
-          reactor
-          |> drop_from_plan(step)
-          |> append_steps(new_steps)
-
-        {recursive_steps, new_steps} ->
-          recursive_steps = Enum.map(recursive_steps, &%{&1 | ref: step.ref})
-
-          reactor
-          |> append_steps(recursive_steps)
-          |> append_steps(new_steps)
-      end
-
-    {:recurse, reactor, state}
+    {:recurse, fold_new_steps_into_plan(reactor, step, new_steps), state}
   end
 
   defp handle_completed_step(reactor, state, {task, step, {:retry, error}}) do
@@ -327,15 +312,45 @@ defmodule Reactor.Executor.Async do
     }
   end
 
-  defp drop_completed_steps_from_plan(reactor, completed_step_results) do
-    completed_step_results
-    |> Enum.filter(fn
-      {_step, {:ok, _value, []}} -> true
-      {_step, {:halt, _value}} -> true
-      _ -> false
+  defp fold_completed_steps_into_plan(reactor, completed_step_results) do
+    Enum.reduce(completed_step_results, reactor, fn
+      # The step completed, possibly emitting new steps. Fold it out of the
+      # plan exactly as normal completion does so that it is not run again on
+      # resume.
+      {step, {:ok, _value, new_steps}}, reactor ->
+        fold_new_steps_into_plan(reactor, step, new_steps)
+
+      # A halt result is a successful completion whose value has already been
+      # stored in the intermediate results, so the step is done.
+      {step, {:halt, _value}}, reactor ->
+        drop_from_plan(reactor, step)
+
+      # Retries, errors, skips and backoffs stay in the plan so that the step
+      # runs again on resume.
+      _other, reactor ->
+        reactor
     end)
-    |> Enum.map(&elem(&1, 0))
-    |> then(&delete_vertices(reactor, &1))
+  end
+
+  defp fold_new_steps_into_plan(reactor, step, new_steps) do
+    case Enum.split_with(new_steps, &(&1.name == step.name)) do
+      # Every emitted step is new work: the completed step is done, and the
+      # new steps are queued for planning.
+      {[], new_steps} ->
+        reactor
+        |> drop_from_plan(step)
+        |> append_steps(new_steps)
+
+      # The step emitted a replacement for itself (eg recursion): re-reference
+      # the replacement so it keeps the original's identity, leaving its
+      # vertex to be replaced when the replacement is planned.
+      {recursive_steps, new_steps} ->
+        recursive_steps = Enum.map(recursive_steps, &%{&1 | ref: step.ref})
+
+        reactor
+        |> append_steps(recursive_steps)
+        |> append_steps(new_steps)
+    end
   end
 
   @doc """
@@ -365,7 +380,7 @@ defmodule Reactor.Executor.Async do
       reactor
       |> store_successful_results_in_the_undo_stack(remaining_step_results)
       |> store_intermediate_results(remaining_step_results)
-      |> drop_completed_steps_from_plan(remaining_step_results)
+      |> fold_completed_steps_into_plan(remaining_step_results)
 
     unfinished_tasks =
       state.current_tasks
@@ -389,7 +404,10 @@ defmodule Reactor.Executor.Async do
 
       unfinished_tasks
       |> Map.keys()
-      |> Enum.each(&Task.ignore/1)
+      |> Enum.each(fn task ->
+        ConcurrencyTracker.release_on_exit(state.concurrency_key, task.pid)
+        Task.ignore(task)
+      end)
     end
 
     {delete_all_task_vertices(reactor), %{state | current_tasks: %{}}}

--- a/lib/reactor/executor/async.ex
+++ b/lib/reactor/executor/async.ex
@@ -348,7 +348,7 @@ defmodule Reactor.Executor.Async do
       remaining_task_results
       |> Map.new(fn {_task, step, result} -> {step, result} end)
 
-    finished_tasks = remaining_step_results |> Enum.map(&elem(&1, 0))
+    finished_tasks = Enum.map(remaining_task_results, &elem(&1, 0))
 
     reactor =
       reactor
@@ -357,7 +357,7 @@ defmodule Reactor.Executor.Async do
 
     unfinished_tasks =
       state.current_tasks
-      |> Map.delete(finished_tasks)
+      |> Map.drop(finished_tasks)
 
     unfinished_task_count = map_size(unfinished_tasks)
 

--- a/lib/reactor/executor/async.ex
+++ b/lib/reactor/executor/async.ex
@@ -327,6 +327,17 @@ defmodule Reactor.Executor.Async do
     }
   end
 
+  defp drop_completed_steps_from_plan(reactor, completed_step_results) do
+    completed_step_results
+    |> Enum.filter(fn
+      {_step, {:ok, _value, []}} -> true
+      {_step, {:halt, _value}} -> true
+      _ -> false
+    end)
+    |> Enum.map(&elem(&1, 0))
+    |> then(&delete_vertices(reactor, &1))
+  end
+
   @doc """
   When the Reactor needs to shut down for any reason, we need to await all the
   currently running asynchronous steps and delete any task vertices.
@@ -354,6 +365,7 @@ defmodule Reactor.Executor.Async do
       reactor
       |> store_successful_results_in_the_undo_stack(remaining_step_results)
       |> store_intermediate_results(remaining_step_results)
+      |> drop_completed_steps_from_plan(remaining_step_results)
 
     unfinished_tasks =
       state.current_tasks

--- a/lib/reactor/executor/concurrency_tracker.ex
+++ b/lib/reactor/executor/concurrency_tracker.ex
@@ -33,24 +33,36 @@ defmodule Reactor.Executor.ConcurrencyTracker do
 
   @doc false
   @impl true
-  @spec init(any) :: {:ok, atom | :ets.tid()}
+  @spec init(any) :: {:ok, %{table: atom | :ets.tid(), releases: %{reference() => pool_key}}}
   def init(_) do
     table = :ets.new(__MODULE__, ~w[set named_table public]a)
-    {:ok, table}
+    {:ok, %{table: table, releases: %{}}}
   end
 
   @doc false
   @impl true
-  def handle_cast({:monitor, pid}, table) do
+  def handle_cast({:monitor, pid}, state) do
     Process.monitor(pid)
-    {:noreply, table}
+    {:noreply, state}
+  end
+
+  def handle_cast({:release_on_exit, pid, pool_key}, state) do
+    ref = Process.monitor(pid)
+    {:noreply, %{state | releases: Map.put(state.releases, ref, pool_key)}}
   end
 
   @doc false
   @impl true
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, table) do
-    :ets.select_delete(table, [{{:_, :_, :_, :"$1"}, [], [{:==, :"$1", pid}]}])
-    {:noreply, table}
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    case Map.pop(state.releases, ref) do
+      {nil, _releases} ->
+        :ets.select_delete(state.table, [{{:_, :_, :_, :"$1"}, [], [{:==, :"$1", pid}]}])
+        {:noreply, state}
+
+      {pool_key, releases} ->
+        release(pool_key)
+        {:noreply, %{state | releases: releases}}
+    end
   end
 
   @doc """
@@ -80,8 +92,12 @@ defmodule Reactor.Executor.ConcurrencyTracker do
   @doc """
   Release concurrency allocation back to the pool.
   """
-  @spec release(pool_key, how_many :: pos_integer) :: :ok | :error
-  def release(key, how_many \\ 1) do
+  @spec release(pool_key, how_many :: non_neg_integer) :: :ok | :error
+  def release(key, how_many \\ 1)
+
+  def release(_key, 0), do: :ok
+
+  def release(key, how_many) do
     # generated using:
     #
     # :ets.fun2ms(fn {key, concurrency_limit, concurrency_available, owner}
@@ -104,6 +120,14 @@ defmodule Reactor.Executor.ConcurrencyTracker do
   end
 
   @doc """
+  Release a concurrency allocation back to the pool when the given process exits.
+  """
+  @spec release_on_exit(pool_key, pid) :: :ok
+  def release_on_exit(pool_key, pid) do
+    GenServer.cast(__MODULE__, {:release_on_exit, pid, pool_key})
+  end
+
+  @doc """
   Attempt to acquire a number of concurrency allocations from the pool.
 
   Returns `{:ok, n}` where `n` was the number of slots that were actually
@@ -114,8 +138,12 @@ defmodule Reactor.Executor.ConcurrencyTracker do
   It is possible for this function to return `{:ok, 0}` if there is no slots
   available.
   """
-  @spec acquire(pool_key, how_many :: pos_integer()) :: {:ok, non_neg_integer()}
-  def acquire(key, how_many \\ 1) do
+  @spec acquire(pool_key, how_many :: non_neg_integer()) :: {:ok, non_neg_integer()}
+  def acquire(key, how_many \\ 1)
+
+  def acquire(_key, 0), do: {:ok, 0}
+
+  def acquire(key, how_many) do
     # generated using:
     #
     # :ets.fun2ms(fn {key, concurrency_limit, concurrency_available, owner}

--- a/test/reactor/executor/concurrency_tracker_test.exs
+++ b/test/reactor/executor/concurrency_tracker_test.exs
@@ -48,6 +48,12 @@ defmodule Reactor.Executor.ConcurrencyTrackerTest do
       assert {:ok, 1} = acquire(pool)
       assert {:ok, 0, 1} = status(pool)
     end
+
+    test "acquiring zero slots acquires nothing" do
+      pool = allocate_pool(4)
+      assert {:ok, 0} = acquire(pool, 0)
+      assert {:ok, 4, 4} = status(pool)
+    end
   end
 
   describe "release/1" do
@@ -64,6 +70,13 @@ defmodule Reactor.Executor.ConcurrencyTrackerTest do
       assert {:ok, 16, 16} = status(pool)
       assert :error = release(pool)
       assert {:ok, 16, 16} = status(pool)
+    end
+
+    test "releasing zero slots releases nothing" do
+      pool = allocate_pool(4)
+      {:ok, 2} = acquire(pool, 2)
+      assert :ok = release(pool, 0)
+      assert {:ok, 2, 4} = status(pool)
     end
   end
 end

--- a/test/reactor/executor_test.exs
+++ b/test/reactor/executor_test.exs
@@ -8,6 +8,7 @@ defmodule Reactor.ExecutorTest do
   alias Reactor.{Builder, Executor.ConcurrencyTracker}
   use ExUnit.Case, async: true
   use Mimic
+  import ExUnit.CaptureLog
 
   describe "synchronous execution" do
     defmodule SyncReactor do
@@ -137,6 +138,65 @@ defmodule Reactor.ExecutorTest do
 
       assert {:ok, "MARTY"} =
                Reactor.Executor.run(reactor, %{name: :marty}, %{}, max_iterations: 100)
+    end
+  end
+
+  describe "halting while an asynchronous step is in flight" do
+    defmodule AsyncHaltReactor do
+      @moduledoc false
+      use Reactor
+
+      step :slow do
+        run(fn _arguments, %{test_pid: test_pid, sleep: sleep} ->
+          Process.sleep(sleep)
+          send(test_pid, :slow_ran)
+          {:ok, :slow}
+        end)
+      end
+
+      step :halter do
+        run(fn _arguments, _context -> {:halt, :waiting} end)
+      end
+
+      return(:slow)
+    end
+
+    test "the in-flight step is awaited and its result kept in the halted reactor" do
+      assert {:halted, halted} =
+               Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 300}, async?: true)
+
+      assert_received :slow_ran
+      assert halted.intermediate_results[:slow] == :slow
+    end
+
+    test "no step is reported as abandoned when the in-flight step completes in time" do
+      log =
+        capture_log(fn ->
+          assert {:halted, _halted} =
+                   Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 300},
+                     async?: true
+                   )
+        end)
+
+      refute log =~ "will be abandoned"
+    end
+
+    test "a reactor which abandoned an in-flight step can be resumed" do
+      capture_log(fn ->
+        assert {:halted, halted} =
+                 Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 500},
+                   async?: true,
+                   halt_timeout: 10
+                 )
+
+        refute_received :slow_ran
+
+        assert {:ok, :slow} =
+                 Reactor.run(halted, %{}, %{test_pid: self(), sleep: 0},
+                   async?: true,
+                   max_iterations: 100
+                 )
+      end)
     end
   end
 

--- a/test/reactor/executor_test.exs
+++ b/test/reactor/executor_test.exs
@@ -196,6 +196,141 @@ defmodule Reactor.ExecutorTest do
       refute log =~ "will be abandoned"
     end
 
+    defmodule DynamicStepHaltReactor do
+      @moduledoc false
+      use Reactor
+
+      defmodule Producer do
+        @moduledoc false
+        use Reactor.Step
+
+        @impl true
+        def run(_arguments, context, _options) do
+          Process.sleep(100)
+          send(context.test_pid, :producer_ran)
+
+          {:ok, step} =
+            Reactor.Builder.new_step(
+              :dynamic,
+              {Reactor.Step.AnonFn, run: fn _arguments, _context -> {:ok, :dynamic} end}
+            )
+
+          {:ok, :produced, [step]}
+        end
+      end
+
+      step(:producer, Producer)
+
+      step :halter do
+        run(fn _arguments, _context -> {:halt, :waiting} end)
+      end
+
+      return(:producer)
+    end
+
+    test "a step which produced new steps while the reactor halted is not run again on resume" do
+      assert {:halted, halted} =
+               Reactor.run(DynamicStepHaltReactor, %{}, %{test_pid: self()}, async?: true)
+
+      assert_received :producer_ran
+
+      assert {:ok, :produced} =
+               Reactor.run(halted, %{}, %{test_pid: self()}, async?: true, max_iterations: 100)
+
+      refute_received :producer_ran
+    end
+
+    defmodule RecursiveHaltReactor do
+      @moduledoc false
+      use Reactor
+
+      defmodule CountDown do
+        @moduledoc false
+        use Reactor.Step
+
+        @impl true
+        def run(%{from: from}, context, _options) do
+          Process.sleep(100)
+          send(context.test_pid, {:counted, :initial})
+          {:ok, [from], [next_step()]}
+        end
+
+        def run(%{numbers: [0 | _] = numbers}, _context, _options),
+          do: {:ok, Enum.reverse(numbers)}
+
+        def run(%{numbers: [number | _] = numbers}, context, _options) do
+          send(context.test_pid, {:counted, number})
+          {:ok, [number - 1 | numbers], [next_step()]}
+        end
+
+        defp next_step do
+          {:ok, step} =
+            Reactor.Builder.new_step(:count_down, __MODULE__, numbers: {:result, :count_down})
+
+          step
+        end
+      end
+
+      input(:from)
+
+      step :count_down, CountDown do
+        argument(:from, input(:from))
+      end
+
+      step :halter do
+        run(fn _arguments, _context -> {:halt, :waiting} end)
+      end
+
+      return(:count_down)
+    end
+
+    test "a recursive step interrupted by a halt continues from where it left off on resume" do
+      assert {:halted, halted} =
+               Reactor.run(RecursiveHaltReactor, %{from: 3}, %{test_pid: self()}, async?: true)
+
+      assert_received {:counted, :initial}
+
+      assert {:ok, [3, 2, 1, 0]} =
+               Reactor.run(halted, %{from: 3}, %{test_pid: self()},
+                 async?: true,
+                 max_iterations: 100
+               )
+
+      refute_received {:counted, :initial}
+      assert_received {:counted, 3}
+    end
+
+    test "abandoning a step does not release its concurrency slot back to a shared pool" do
+      concurrency_key = ConcurrencyTracker.allocate_pool(4)
+
+      capture_log(fn ->
+        assert {:halted, _halted} =
+                 Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 500},
+                   async?: true,
+                   halt_timeout: 10,
+                   concurrency_key: concurrency_key
+                 )
+      end)
+
+      assert {:ok, 3, 4} = ConcurrencyTracker.status(concurrency_key)
+    end
+
+    test "an abandoned step's concurrency slot returns to a shared pool when the step eventually finishes" do
+      concurrency_key = ConcurrencyTracker.allocate_pool(4)
+
+      capture_log(fn ->
+        assert {:halted, _halted} =
+                 Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 200},
+                   async?: true,
+                   halt_timeout: 10,
+                   concurrency_key: concurrency_key
+                 )
+      end)
+
+      assert_receive :slow_ran, 1_000
+      assert {:ok, 4, 4} = await_status(concurrency_key, {:ok, 4, 4})
+    end
+
     test "a reactor which abandoned an in-flight step can be resumed" do
       capture_log(fn ->
         assert {:halted, halted} =
@@ -444,6 +579,19 @@ defmodule Reactor.ExecutorTest do
       assert elapsed >= 100 and elapsed <= 500
     end
 
+    defp await_status(concurrency_key, expected) do
+      Enum.reduce_while(1..100, ConcurrencyTracker.status(concurrency_key), fn _, _ ->
+        case ConcurrencyTracker.status(concurrency_key) do
+          ^expected ->
+            {:halt, expected}
+
+          other ->
+            Process.sleep(10)
+            {:cont, other}
+        end
+      end)
+    end
+
     defp measure_elapsed(fun) do
       started_at = DateTime.utc_now()
 
@@ -454,6 +602,37 @@ defmodule Reactor.ExecutorTest do
   end
 
   describe "reactor timeout" do
+    defmodule SlowStepReactor do
+      @moduledoc false
+      use Reactor
+
+      step :slow do
+        run(fn _arguments, _context ->
+          Process.sleep(300)
+          {:ok, :slow}
+        end)
+      end
+
+      return(:slow)
+    end
+
+    test "an in-flight step completing within the halt timeout is kept and not reported as abandoned" do
+      log =
+        capture_log(fn ->
+          assert {:halted, halted} =
+                   Reactor.run(SlowStepReactor, %{}, %{},
+                     async?: true,
+                     timeout: 100,
+                     halt_timeout: 1_000
+                   )
+
+          assert halted.intermediate_results[:slow] == :slow
+          assert {:ok, :slow} = Reactor.run(halted, %{}, %{}, async?: true)
+        end)
+
+      refute log =~ "will be abandoned"
+    end
+
     test "when the timeout is elapsed, it halts the reactor" do
       elapsed =
         measure_elapsed(fn ->

--- a/test/reactor/executor_test.exs
+++ b/test/reactor/executor_test.exs
@@ -169,6 +169,21 @@ defmodule Reactor.ExecutorTest do
       assert halted.intermediate_results[:slow] == :slow
     end
 
+    test "a step which completed while the reactor halted is not run again on resume" do
+      assert {:halted, halted} =
+               Reactor.run(AsyncHaltReactor, %{}, %{test_pid: self(), sleep: 300}, async?: true)
+
+      assert_received :slow_ran
+
+      assert {:ok, :slow} =
+               Reactor.run(halted, %{}, %{test_pid: self(), sleep: 0},
+                 async?: true,
+                 max_iterations: 100
+               )
+
+      refute_received :slow_ran
+    end
+
     test "no step is reported as abandoned when the in-flight step completes in time" do
       log =
         capture_log(fn ->


### PR DESCRIPTION
Fixes #323.

## Problem

`halt_timeout` is documented as "how long to wait for asynchronous steps to complete when
halting", but it was only consulted when the reactor halted on `timeout` or `max_iterations`.
When a step returned `{:halt, value}`, in-flight async steps were neither awaited nor stopped.

Two consequences:

1. An abandoned step ran to completion after `Reactor.run/4` returned, and its result was
   discarded. Being absent from the halted reactor, it ran again on resume — its effect
   happened twice.
2. The `:executing` edge from a task to its step is how the executor knows not to start that
   step twice, and it is removed only when that task's result is collected. So the halted
   reactor claimed the step was still executing, while carrying no way to ever collect that
   task: the executor state is rebuilt on resume with empty `current_tasks`, the step keeps
   its in-edge, is never ready, and the resume spins to `max_iterations`.

## Approach

The `{:halt, ...}` branch of `Executor.execute/2` is the single point where in-flight tasks
are collected: wait `halt_timeout` for running tasks, fold in whatever completes, and drop all
task vertices so the returned reactor is resumable whether or not the steps finished. Both
step-halt and timeout reach this branch; the iteration-limit clause calls the collector
directly.

`collect_remaining_tasks_for_shutdown/2` needed several corrections of its own:

- It computed its abandoned-task set by passing a list of steps to `Map.delete/2` as a single
  key, so every task was reported abandoned in the warning and `Task.ignore/1` was called on
  tasks that had already completed.
- Collected results were folded into intermediate results and the undo stack while their step
  vertices stayed in the plan, so completed steps ran again on resume. Shutdown now folds
  completed steps out of the plan with the same logic as normal completion
  (`fold_new_steps_into_plan/3`, shared with `handle_completed_step/3`), covering plain
  completions, emitted steps and recursive self-replacements. Retries, errors, skips and
  backoffs stay in the plan and run again on resume.
- With zero collected results it called `ConcurrencyTracker.release(key, 0)`, which enumerated
  the decreasing range `1..0` and released up to two slots. Zero-count `release/2` and
  `acquire/2` are now no-ops.
- An abandoned task's shared-pool slot was never returned once the task exited, permanently
  shrinking the pool. The tracker now monitors abandoned task pids (`release_on_exit/2`) and
  releases the slot on termination.

A step whose result arrives during the halt wait keeps the existing semantics of the timeout
path: `:ok` and `:halt` results are folded into intermediate results and the undo stack,
errors are discarded.

## Testing

Halt with an async step in flight: the in-flight result is retained; the completed step is not
re-run on resume; a step emitting new steps is not re-run and its emitted steps run on resume;
an interrupted recursive step continues where it left off; no step is falsely reported as
abandoned; a reactor that genuinely abandoned a step resumes to completion; shared-pool
accounting holds both while an abandoned task runs and after it exits. Timeout: an in-flight
step completing within `halt_timeout` is kept and not reported as abandoned. `mix check
--no-retry` passes.
