### PR TITLE
fix: wrap async step task exits in a `RunStepError`

### DIFF
--- a/lib/reactor/executor/async.ex
+++ b/lib/reactor/executor/async.ex
@@ -8,7 +8,14 @@ defmodule Reactor.Executor.Async do
   Handle the asynchronous execution of a batch of steps, along with any
   mutations to the reactor or execution state.
   """
-  alias Reactor.{Error.Invalid.RetriesExceededError, Executor, Executor.ConcurrencyTracker, Step}
+  alias Reactor.{
+    Error.Invalid.RetriesExceededError,
+    Error.Invalid.RunStepError,
+    Executor,
+    Executor.ConcurrencyTracker,
+    Step
+  }
+
   require Logger
 
   @doc """
@@ -196,17 +203,16 @@ defmodule Reactor.Executor.Async do
     |> Map.keys()
     |> Task.yield_many(opts)
     |> Stream.reject(&is_nil(elem(&1, 1)))
-    |> Stream.map(fn
-      {task, {:ok, result}} ->
-        {task, normalise_result(result)}
-
-      {task, {:exit, reason}} ->
-        {task, normalise_result({:error, reason})}
-    end)
-    |> Enum.map(fn {task, result} ->
-      {task, Map.fetch!(current_tasks, task), result}
+    |> Enum.map(fn {task, outcome} ->
+      step = Map.fetch!(current_tasks, task)
+      {task, step, normalise_outcome(outcome, step)}
     end)
   end
+
+  defp normalise_outcome({:ok, result}, _step), do: normalise_result(result)
+
+  defp normalise_outcome({:exit, reason}, step),
+    do: {:error, RunStepError.exception(step: step, error: reason)}
 
   defp normalise_result({:error, reason}), do: {:error, reason}
   defp normalise_result({:halt, reason}), do: {:halt, reason}

--- a/test/reactor/executor/async_test.exs
+++ b/test/reactor/executor/async_test.exs
@@ -5,6 +5,7 @@
 
 defmodule Reactor.Executor.AsyncTest do
   alias Reactor.Error.Invalid.RetriesExceededError, as: RetriesExceededError
+  alias Reactor.Error.Invalid.RunStepError, as: RunStepError
   alias Reactor.Executor
   import Reactor.Executor.Async
   use ExUnit.Case, async: true
@@ -201,6 +202,29 @@ defmodule Reactor.Executor.AsyncTest do
       assert [{doable.name, :mcfly}] == Enum.to_list(reactor.intermediate_results)
     end
 
+    @tag :capture_log
+    test "when one of the step's tasks exits, the exit reason is wrapped in a run step error",
+         %{reactor: reactor, state: state, doable: doable, supervisor: supervisor} do
+      reason = {:noproc, {GenServer, :call, [:some_name, :ping, 5000]}}
+      state = %{state | current_tasks: %{exited_task(supervisor, reason) => doable}}
+
+      assert {:undo, _reactor, state} = handle_completed_steps(reactor, state)
+      assert [%RunStepError{step: ^doable, error: ^reason}] = state.errors
+    end
+
+    @tag :capture_log
+    test "when one of the step's tasks exits, the collected errors can be turned into a class",
+         %{reactor: reactor, state: state, doable: doable, supervisor: supervisor} do
+      reason = {:noproc, {GenServer, :call, [:some_name, :ping, 5000]}}
+      state = %{state | current_tasks: %{exited_task(supervisor, reason) => doable}}
+
+      assert {:undo, _reactor, state} = handle_completed_steps(reactor, state)
+
+      message = state.errors |> Reactor.Error.to_class() |> Exception.message()
+      assert message =~ "noproc"
+      assert message =~ "GenServer"
+    end
+
     test "when one of the steps asks to retry, it puts the step back in the reactor plan",
          %{reactor: reactor, state: state, doable: step, supervisor: supervisor} do
       task = Task.Supervisor.async_nolink(supervisor, fn -> :retry end)
@@ -235,5 +259,12 @@ defmodule Reactor.Executor.AsyncTest do
       assert {:undo, _reactor, %{errors: [%RetriesExceededError{}]}} =
                handle_completed_steps(reactor, state)
     end
+  end
+
+  defp exited_task(supervisor, reason) do
+    task = Task.Supervisor.async_nolink(supervisor, fn -> exit(reason) end)
+    ref = Process.monitor(task.pid)
+    assert_receive {:DOWN, ^ref, :process, _, _}, 5000
+    task
   end
 end


### PR DESCRIPTION
Fixes #327.

When an asynchronous step's task exited rather than returning, `get_normalised_task_results/2` turned `{:exit, reason}` into `{:error, reason}` and put the bare OTP exit term into `state.errors`. `StepRunner` never sees it, so unlike returned or raised errors it was never wrapped in `RunStepError` — exits were the only step failures to lose their step attribution.

It also meant the reactor could fail to report the error at all. Exit reasons like `{:noproc, {GenServer, :call, [:name, :ping, 5000]}}` are two-element tuples with an atom key, so a list of them satisfies `Keyword.keyword?/1`; splode's `to_error/2` destructured it as a list of error options and passed `value:`, which `Reactor.Error.Unknown.UnknownError` doesn't declare. The resulting `KeyError: key :value not found` was raised from `Reactor.Error.to_class/1` inside `handle_undo/3` — before `Executor.Hooks.error/3` — so it replaced the original error and skipped the error hooks.

The exit is now wrapped where the step is already in scope:

```
# Run Step Error
An error occurred while attempting to run the `:boom` step.
## `error`:
`{:noproc, {GenServer, :call, [:definitely_not_running, :ping, 5000]}}`
```

`normalise_result/1` is unchanged; the new `normalise_outcome/2` handles the `Task.yield_many/2` outcome, which is what needs the step.

## Tests

Two tests, both of which fail on `main` — the second with the reported `KeyError` exactly. `exited_task/2` waits on a separate monitor for the task to actually die before polling, so the tests don't race the scheduler; verified clean across 20 seeds.

## Scope

Splode treating any keyword-ish list as error options is a genuine bug in its own right and is fixed by ash-project/splode#127, but reactor shouldn't be handing it a raw exit reason regardless. This change stands alone against splode 0.3.1 — no version bump needed.

`mix check --no-retry` passes.