### PR TITLE
fix: missing questionmark in strict_ordering? argument name

### DIFF
--- a/lib/reactor/dsl/map.ex
+++ b/lib/reactor/dsl/map.ex
@@ -189,7 +189,7 @@ defmodule Reactor.Dsl.Map do
 
         step_options =
           map
-          |> Map.take([:allow_async?, :batch_size, :return, :strict_ordering])
+          |> Map.take([:allow_async?, :batch_size, :return, :strict_ordering?])
           |> Map.put(:state, :init)
           |> Map.put(:steps, sub_reactor.steps)
           |> Map.update!(:return, fn

--- a/test/reactor/dsl/map_test.exs
+++ b/test/reactor/dsl/map_test.exs
@@ -38,4 +38,54 @@ defmodule Reactor.Dsl.MapTest do
     assert [0, 4, 8, 12, 16, 20] =
              Reactor.run!(MapOverNumbersReactor, %{numbers: numbers}, %{}, async?: false)
   end
+
+  defmodule MapWithStrictOrderingFalseReactor do
+    @moduledoc false
+    use Reactor
+
+    input :numbers
+
+    map :map_over_numbers do
+      source(input(:numbers))
+      strict_ordering?(false)
+
+      step :double do
+        argument :input, element(:map_over_numbers)
+
+        run fn %{input: input}, _ ->
+          {:ok, input * 2}
+        end
+      end
+    end
+  end
+
+  describe "strict_ordering? option" do
+    test "is passed through to the step" do
+      {:ok, reactor_struct} = Reactor.Info.to_struct(MapWithStrictOrderingFalseReactor)
+
+      map_step =
+        Enum.find(reactor_struct.steps, fn step ->
+          step.name == :map_over_numbers
+        end)
+
+      assert map_step != nil
+      assert match?({Reactor.Step.Map, _opts}, map_step.impl)
+      {_module, opts} = map_step.impl
+      assert Keyword.get(opts, :strict_ordering?) == false
+    end
+
+    test "defaults to true when not specified" do
+      {:ok, reactor_struct} = Reactor.Info.to_struct(MapOverNumbersReactor)
+
+      map_step =
+        Enum.find(reactor_struct.steps, fn step ->
+          step.name == :map_over_numbers
+        end)
+
+      assert map_step != nil
+      assert match?({Reactor.Step.Map, _opts}, map_step.impl)
+      {_module, opts} = map_step.impl
+      assert Keyword.get(opts, :strict_ordering?, true) == true
+    end
+  end
 end


### PR DESCRIPTION
The `map` dsl has an option `strict_ordering?` but the option was taken from the map step without the questionmark.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
