### PR TITLE
docs: add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,7 @@ defmodule Reactor.MixProject do
             Internals: ~r/^Reactor\..*/
           ],
           extra_section: "GUIDES",
-          formatters: ["html"],
+          formatters: ["html", "markdown"],
           filter_modules: ~r/^Elixir.Reactor/,
           source_url_pattern: "https://github.com/ash-project/reactor/blob/main/%{path}/#L%{line}"
         ]


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Reactor pins an explicit `formatters:` list, so it does not inherit that default.

This adds only `"markdown"` to the existing list. HTML output is unchanged, and no other formatter is added or removed.

As precedent within the same organization, [`ash-project/ash`](https://github.com/ash-project/ash) does not pin `formatters:` and its published [`llms.txt`](https://hexdocs.pm/ash/llms.txt) returns HTTP 200.

Verified with:
- `mix docs` (emits `doc/llms.txt` and Markdown pages)
- `mix check --no-retry`

This PR was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP